### PR TITLE
Add --export-for-letterboxd option for ratings command

### DIFF
--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -17,9 +17,13 @@ func main() {
 
 	watchlistCmd := flag.NewFlagSet("watchlist", flag.ExitOnError)
 	watchlistUserId := watchlistCmd.Int64("userid", 0, "Mubi.com user ID")
+	watchlistPage := watchlistCmd.Int("page", 1, "Results page number")
+	watchlistPerPage := watchlistCmd.Int("per-page", 20, "Number of results per page")
 
 	favouriteFilmsCmd := flag.NewFlagSet("favourite-films", flag.ExitOnError)
 	favouriteFilmsUserId := favouriteFilmsCmd.Int64("userid", 0, "Mubi.com user ID")
+	favouriteFilmsPage := favouriteFilmsCmd.Int("page", 1, "Results page number")
+	favouriteFilmsPerPage := favouriteFilmsCmd.Int("per-page", 20, "Number of results per page")
 
 	if len(os.Args) < 2 {
 		fmt.Println("no subcommand provided")
@@ -34,10 +38,10 @@ func main() {
 		printRatings(*api, *ratingsUserId, *ratingsPage, *ratingsPerPage)
 	case "watchlist":
 		watchlistCmd.Parse(os.Args[2:])
-		printWatchlist(*api, *watchlistUserId)
+		printWatchlist(*api, *watchlistUserId, *watchlistPage, *watchlistPerPage)
 	case "favourite-films":
 		favouriteFilmsCmd.Parse(os.Args[2:])
-		printFavouriteFilms(*api, *favouriteFilmsUserId)
+		printFavouriteFilms(*api, *favouriteFilmsUserId, *favouriteFilmsPage, *favouriteFilmsPerPage)
 	default:
 		fmt.Println("unexpected subcommand provided")
 		os.Exit(1)
@@ -61,8 +65,8 @@ func printRatings(api mubi.MubiAPI, userId int64, page int, perPage int) {
 	}
 }
 
-func printWatchlist(api mubi.MubiAPI, userId int64) {
-	watchlist := api.GetWatchlist(userId, 1, 20)
+func printWatchlist(api mubi.MubiAPI, userId int64, page int, perPage int) {
+	watchlist := api.GetWatchlist(userId, page, perPage)
 	for _, item := range watchlist {
 		fmt.Printf("%s (%d) - %s\n", item.Film.Title, item.Film.Year, item.Film.CanonicalUrl)
 
@@ -78,8 +82,8 @@ func printWatchlist(api mubi.MubiAPI, userId int64) {
 	}
 }
 
-func printFavouriteFilms(api mubi.MubiAPI, userId int64) {
-	favourites := api.GetFavouriteFilms(userId, 1, 20)
+func printFavouriteFilms(api mubi.MubiAPI, userId int64, page int, perPage int) {
+	favourites := api.GetFavouriteFilms(userId, page, perPage)
 	for _, fav := range favourites {
 		fmt.Printf("%s (%d) - %s\n", fav.Fannable.Film.Title, fav.Fannable.Film.Year, fav.Fannable.Film.CanonicalUrl)
 

--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/csv"
 	"flag"
 	"fmt"
 	"github.com/jdennes/mubi"
+	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -77,7 +80,30 @@ func printRatingsStandard(ratings []mubi.Rating) {
 func printRatingsForLetterboxd(ratings []mubi.Rating) {
 	// Print CSV output for Letterboxd importer as defined here:
 	// https://letterboxd.com/about/importing-data/
-	fmt.Printf("TODO!\n")
+	lines := [][]string{{"Title", "Year", "Directors", "Rating", "WatchedDate"}}
+	for _, rating := range ratings {
+		var directorNames []string
+		for _, director := range rating.Film.Directors {
+			directorNames = append(directorNames, director.Name)
+		}
+		when := time.Unix(rating.Timestamp, 0)
+
+		line := []string{
+			rating.Film.Title,
+			strconv.Itoa(rating.Film.Year),
+			strings.Join(directorNames, ", "),
+			strconv.Itoa(rating.Overall),
+			when.Format("2006-01-02"),
+		}
+		lines = append(lines, line)
+	}
+
+	writer := csv.NewWriter(os.Stdout)
+	writer.WriteAll(lines)
+
+	if err := writer.Error(); err != nil {
+		log.Fatalln("Error writing CSV:", err)
+	}
 }
 
 func printWatchlist(api mubi.MubiAPI, userId int64, page int, perPage int) {

--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -12,6 +12,8 @@ import (
 func main() {
 	ratingsCmd := flag.NewFlagSet("ratings", flag.ExitOnError)
 	ratingsUserId := ratingsCmd.Int64("userid", 0, "Mubi.com user ID")
+	ratingsPage := ratingsCmd.Int("page", 1, "Results page number")
+	ratingsPerPage := ratingsCmd.Int("per-page", 20, "Number of results per page")
 
 	watchlistCmd := flag.NewFlagSet("watchlist", flag.ExitOnError)
 	watchlistUserId := watchlistCmd.Int64("userid", 0, "Mubi.com user ID")
@@ -29,7 +31,7 @@ func main() {
 	switch os.Args[1] {
 	case "ratings":
 		ratingsCmd.Parse(os.Args[2:])
-		printRatings(*api, *ratingsUserId)
+		printRatings(*api, *ratingsUserId, *ratingsPage, *ratingsPerPage)
 	case "watchlist":
 		watchlistCmd.Parse(os.Args[2:])
 		printWatchlist(*api, *watchlistUserId)
@@ -42,8 +44,8 @@ func main() {
 	}
 }
 
-func printRatings(api mubi.MubiAPI, userId int64) {
-	ratings := api.GetRatings(userId, 1, 20)
+func printRatings(api mubi.MubiAPI, userId int64, page int, perPage int) {
+	ratings := api.GetRatings(userId, page, perPage)
 	for _, rating := range ratings {
 		fmt.Printf("%s (%d) - %s\n", rating.Film.Title, rating.Film.Year, rating.Film.CanonicalUrl)
 

--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -14,6 +14,7 @@ func main() {
 	ratingsUserId := ratingsCmd.Int64("userid", 0, "Mubi.com user ID")
 	ratingsPage := ratingsCmd.Int("page", 1, "Results page number")
 	ratingsPerPage := ratingsCmd.Int("per-page", 20, "Number of results per page")
+	ratingsExportForLetterboxd := ratingsCmd.Bool("export-for-letterboxd", false, "If true, print output in CSV format for Letterboxd importer")
 
 	watchlistCmd := flag.NewFlagSet("watchlist", flag.ExitOnError)
 	watchlistUserId := watchlistCmd.Int64("userid", 0, "Mubi.com user ID")
@@ -35,7 +36,7 @@ func main() {
 	switch os.Args[1] {
 	case "ratings":
 		ratingsCmd.Parse(os.Args[2:])
-		printRatings(*api, *ratingsUserId, *ratingsPage, *ratingsPerPage)
+		printRatings(*api, *ratingsUserId, *ratingsPage, *ratingsPerPage, *ratingsExportForLetterboxd)
 	case "watchlist":
 		watchlistCmd.Parse(os.Args[2:])
 		printWatchlist(*api, *watchlistUserId, *watchlistPage, *watchlistPerPage)
@@ -48,8 +49,16 @@ func main() {
 	}
 }
 
-func printRatings(api mubi.MubiAPI, userId int64, page int, perPage int) {
+func printRatings(api mubi.MubiAPI, userId int64, page int, perPage int, exportForLetterboxd bool) {
 	ratings := api.GetRatings(userId, page, perPage)
+	if exportForLetterboxd == true {
+		printRatingsForLetterboxd(ratings)
+	} else {
+		printRatingsStandard(ratings)
+	}
+}
+
+func printRatingsStandard(ratings []mubi.Rating) {
 	for _, rating := range ratings {
 		fmt.Printf("%s (%d) - %s\n", rating.Film.Title, rating.Film.Year, rating.Film.CanonicalUrl)
 
@@ -63,6 +72,12 @@ func printRatings(api mubi.MubiAPI, userId int64, page int, perPage int) {
 		fmt.Printf("Rated %d/5 stars on %s\n", rating.Overall, when)
 		fmt.Printf("-----\n")
 	}
+}
+
+func printRatingsForLetterboxd(ratings []mubi.Rating) {
+	// Print CSV output for Letterboxd importer as defined here:
+	// https://letterboxd.com/about/importing-data/
+	fmt.Printf("TODO!\n")
 }
 
 func printWatchlist(api mubi.MubiAPI, userId int64, page int, perPage int) {


### PR DESCRIPTION
This adds the `--export-for-letterboxd` option for the `ratings` command:

Without the `--export-for-letterboxd` option:

```
$ mubi ratings --userid=7995037 --page=1 --per-page=5
Dear Zachary (2008) - http://mubi.com/films/dear-zachary
Directed by Kurt Kuenne
Rated 4/5 stars on 2020-08-28 23:47:58 +0200 CEST
-----
Papicha (2019) - http://mubi.com/films/papicha
Directed by Mounia Meddour Gens
Rated 5/5 stars on 2020-08-26 22:15:02 +0200 CEST
-----
Leviathan (2014) - http://mubi.com/films/leviathan-2014
Directed by Andrey Zvyagintsev
Rated 5/5 stars on 2020-08-19 18:47:59 +0200 CEST
-----
Amy (2015) - http://mubi.com/films/amy-2015
Directed by Asif Kapadia
Rated 4/5 stars on 2020-08-18 11:23:48 +0200 CEST
-----
Hoop Dreams (1994) - http://mubi.com/films/hoop-dreams
Directed by Steve James
Rated 4/5 stars on 2020-08-18 10:58:18 +0200 CEST
-----
```

With the `--export-for-letterboxd` option

```
$ mubi ratings --userid=7995037 --page=1 --per-page=5 --export-for-letterboxd
Title,Year,Directors,Rating,WatchedDate
Dear Zachary,2008,Kurt Kuenne,4,2020-08-28
Papicha,2019,Mounia Meddour Gens,5,2020-08-26
Leviathan,2014,Andrey Zvyagintsev,5,2020-08-19
Amy,2015,Asif Kapadia,4,2020-08-18
Hoop Dreams,1994,Steve James,4,2020-08-18
```

The `--export-for-letterboxd` output can be used to import a Mubi user's film ratings to Letterboxd at https://letterboxd.com/import/.

Letterboxd import format is documented here: https://letterboxd.com/about/importing-data/
