### PR TITLE
Support getting list of users someone is following

### DIFF
--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -29,6 +29,11 @@ func main() {
 	favouriteFilmsPage := favouriteFilmsCmd.Int("page", 1, "Results page number")
 	favouriteFilmsPerPage := favouriteFilmsCmd.Int("per-page", 20, "Number of results per page")
 
+	followingCmd := flag.NewFlagSet("following", flag.ExitOnError)
+	followingUserId := followingCmd.Int64("userid", 0, "Mubi.com user ID")
+	followingPage := followingCmd.Int("page", 1, "Results page number")
+	followingPerPage := followingCmd.Int("per-page", 20, "Number of results per page")
+
 	if len(os.Args) < 2 {
 		fmt.Println("no subcommand provided")
 		os.Exit(1)
@@ -48,6 +53,9 @@ func main() {
 		printFavouriteFilms(*api, *favouriteFilmsUserId, *favouriteFilmsPage, *favouriteFilmsPerPage)
 	case "films-of-the-day":
 		printFilmsOfTheDay(*api)
+	case "following":
+		followingCmd.Parse(os.Args[2:])
+		printFollowing(*api, *followingUserId, *followingPage, *followingPerPage)
 	default:
 		fmt.Println("unexpected subcommand provided")
 		os.Exit(1)
@@ -147,6 +155,17 @@ func printFilmsOfTheDay(api mubi.MubiAPI) {
 	for _, fotd := range filmsOfTheDay {
 		fmt.Printf("%s (%d) - %s\n", fotd.Film.Title, fotd.Film.Year, fotd.Film.WebUrl)
 		fmt.Printf("Expires %s\n", fotd.ExpiresAt)
+		fmt.Printf("-----\n")
+	}
+}
+
+func printFollowing(api mubi.MubiAPI, userId int64, page int, perPage int) {
+	following := api.GetFollowing(userId, page, perPage)
+	for _, item := range following {
+		fmt.Printf("%s - %s\n", item.Followee.Name, item.Followee.CanonicalUrl)
+		fmt.Printf("Bio: %s\n", item.Followee.Bio)
+		when := time.Unix(item.CreatedAt, 0)
+		fmt.Printf("Followed on %s\n", when)
 		fmt.Printf("-----\n")
 	}
 }

--- a/following.go
+++ b/following.go
@@ -1,0 +1,29 @@
+package mubi
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+type FollowingItem struct {
+	Id        int   `json:id`
+	CreatedAt int64 `json:"created_at"`
+	Followee  User  `json:followee`
+}
+
+func (api *MubiAPI) GetFollowing(userId int64, page int, perPage int) []FollowingItem {
+	url := fmt.Sprintf(
+		"https://mubi.com/services/api/followings?user_id=%d&page=%d&per_page=%d",
+		userId, page, perPage,
+	)
+
+	body := api.GetResponseBody(url)
+	following := make([]FollowingItem, 0)
+	jsonErr := json.Unmarshal(body, &following)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return following
+}

--- a/following_test.go
+++ b/following_test.go
@@ -1,0 +1,35 @@
+package mubi
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestGetFollowing(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		file, _ := os.Open("testdata/mubi-following-sample.json")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(file),
+			Header:     make(http.Header),
+		}
+	})
+
+	api := MubiAPI{client}
+	userId, page, perPage := int64(7995037), 1, 20
+	following := api.GetFollowing(userId, page, perPage)
+
+	if len(following) != 2 {
+		t.Errorf("Number of following items was incorrect. Got: %d, expected: %d.", len(following), 2)
+	}
+
+	if following[0].Followee.Name != "Manuel" {
+		t.Errorf("Name of first followed user was incorrect. Got: %s, expected: %s.", following[0].Followee.Name, "Manuel")
+	}
+
+	if following[1].Followee.Name != "josé neves" {
+		t.Errorf("Name of second followed user was incorrect. Got: %s, expected: %s.", following[1].Followee.Name, "josé neves")
+	}
+}

--- a/testdata/mubi-following-sample.json
+++ b/testdata/mubi-following-sample.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": 6600683,
+    "followee_id": 10856256,
+    "follower_id": 7995037,
+    "created_at": 1624198972,
+    "followee": {
+      "id": 10856256,
+      "name": "Manuel",
+      "canonical_url": "https://mubi.com/users/10856256",
+      "avatar_url": "//mubi.com/assets/placeholders/avatar-2b64b89b674f3bee3279c73763e9588cd01989594c56f2f96da75963e3f41285.png",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": null,
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 7995037,
+      "name": "jdennes",
+      "canonical_url": "https://mubi.com/users/7995037",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/113982/cache-113982-1523900231/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/80119/images-small.jpg?1535047013",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6428178,
+    "followee_id": 6164674,
+    "follower_id": 7995037,
+    "created_at": 1569176369,
+    "followee": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    },
+    "follower": {
+      "id": 7995037,
+      "name": "jdennes",
+      "canonical_url": "https://mubi.com/users/7995037",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/113982/cache-113982-1523900231/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/80119/images-small.jpg?1535047013",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  }
+]

--- a/user.go
+++ b/user.go
@@ -1,0 +1,10 @@
+package mubi
+
+type User struct {
+	Id           int    `json:id`
+	Name         string `json:name`
+	CanonicalUrl string `json:"canonical_url"`
+	AvartarUrl   string `json:"avatar_url"`
+	Bio          string `json:bio`
+	Subscriber   bool   `json:subscriber`
+}


### PR DESCRIPTION
This branch adds support for getting the list of users someone is following on Mubi.

Supports usage something like this:

```go
package main

import (
	"github.com/jdennes/mubi"
)

func main() {
	api := mubi.NewMubiAPI()
	userId, page, perPage := int64(7995037), 1, 20
	following := api.GetFollowing(userId, page, perPage)
	// etc
}
```

And adds an example command:

```
$ mubi following --userid 7995037

Manuel - https://mubi.com/users/10856256
Bio: 
Followed on 2021-06-20 16:22:52 +0200 CEST
-----
josé neves - https://mubi.com/users/6164674
Bio: "There was a boy/A very strange enchanted boy"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he."
Followed on 2019-09-22 20:19:29 +0200 CEST
-----
```