### PR TITLE
Support getting a user's followers

### DIFF
--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -34,6 +34,11 @@ func main() {
 	followingPage := followingCmd.Int("page", 1, "Results page number")
 	followingPerPage := followingCmd.Int("per-page", 20, "Number of results per page")
 
+	followersCmd := flag.NewFlagSet("followers", flag.ExitOnError)
+	followersUserId := followersCmd.Int64("userid", 0, "Mubi.com user ID")
+	followersPage := followersCmd.Int("page", 1, "Results page number")
+	followersPerPage := followersCmd.Int("per-page", 20, "Number of results per page")
+
 	if len(os.Args) < 2 {
 		fmt.Println("no subcommand provided")
 		os.Exit(1)
@@ -56,6 +61,9 @@ func main() {
 	case "following":
 		followingCmd.Parse(os.Args[2:])
 		printFollowing(*api, *followingUserId, *followingPage, *followingPerPage)
+	case "followers":
+		followersCmd.Parse(os.Args[2:])
+		printFollowers(*api, *followersUserId, *followersPage, *followersPerPage)
 	default:
 		fmt.Println("unexpected subcommand provided")
 		os.Exit(1)
@@ -164,6 +172,17 @@ func printFollowing(api mubi.MubiAPI, userId int64, page int, perPage int) {
 	for _, item := range following {
 		fmt.Printf("%s - %s\n", item.Followee.Name, item.Followee.CanonicalUrl)
 		fmt.Printf("Bio: %s\n", item.Followee.Bio)
+		when := time.Unix(item.CreatedAt, 0)
+		fmt.Printf("Followed on %s\n", when)
+		fmt.Printf("-----\n")
+	}
+}
+
+func printFollowers(api mubi.MubiAPI, userId int64, page int, perPage int) {
+	followers := api.GetFollowers(userId, page, perPage)
+	for _, item := range followers {
+		fmt.Printf("%s - %s\n", item.Follower.Name, item.Follower.CanonicalUrl)
+		fmt.Printf("Bio: %s\n", item.Follower.Bio)
 		when := time.Unix(item.CreatedAt, 0)
 		fmt.Printf("Followed on %s\n", when)
 		fmt.Printf("-----\n")

--- a/followers.go
+++ b/followers.go
@@ -1,0 +1,29 @@
+package mubi
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+type FollowerItem struct {
+	Id        int   `json:id`
+	CreatedAt int64 `json:"created_at"`
+	Follower  User  `json:follower`
+}
+
+func (api *MubiAPI) GetFollowers(userId int64, page int, perPage int) []FollowerItem {
+	url := fmt.Sprintf(
+		"https://mubi.com/services/api/followings/followers?user_id=%d&page=%d&per_page=%d",
+		userId, page, perPage,
+	)
+
+	body := api.GetResponseBody(url)
+	followers := make([]FollowerItem, 0)
+	jsonErr := json.Unmarshal(body, &followers)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return followers
+}

--- a/followers_test.go
+++ b/followers_test.go
@@ -1,0 +1,35 @@
+package mubi
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestGetFollowers(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		file, _ := os.Open("testdata/mubi-followers-sample.json")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(file),
+			Header:     make(http.Header),
+		}
+	})
+
+	api := MubiAPI{client}
+	userId, page, perPage := int64(6164674), 1, 20
+	followers := api.GetFollowers(userId, page, perPage)
+
+	if len(followers) != 20 {
+		t.Errorf("Number of follower items was incorrect. Got: %d, expected: %d.", len(followers), 20)
+	}
+
+	if followers[0].Follower.Name != "Ryuu Baron" {
+		t.Errorf("Name of first followed user was incorrect. Got: %s, expected: %s.", followers[0].Follower.Name, "Ryuu Baron")
+	}
+
+	if followers[1].Follower.Name != "Filip Klokan" {
+		t.Errorf("Name of second followed user was incorrect. Got: %s, expected: %s.", followers[1].Follower.Name, "Filip Klokan")
+	}
+}

--- a/following_test.go
+++ b/following_test.go
@@ -18,18 +18,18 @@ func TestGetFollowing(t *testing.T) {
 	})
 
 	api := MubiAPI{client}
-	userId, page, perPage := int64(7995037), 1, 20
+	userId, page, perPage := int64(6164674), 1, 20
 	following := api.GetFollowing(userId, page, perPage)
 
-	if len(following) != 2 {
-		t.Errorf("Number of following items was incorrect. Got: %d, expected: %d.", len(following), 2)
+	if len(following) != 20 {
+		t.Errorf("Number of following items was incorrect. Got: %d, expected: %d.", len(following), 20)
 	}
 
-	if following[0].Followee.Name != "Manuel" {
-		t.Errorf("Name of first followed user was incorrect. Got: %s, expected: %s.", following[0].Followee.Name, "Manuel")
+	if following[0].Followee.Name != "mubianer" {
+		t.Errorf("Name of first followed user was incorrect. Got: %s, expected: %s.", following[0].Followee.Name, "mubianer")
 	}
 
-	if following[1].Followee.Name != "josé neves" {
-		t.Errorf("Name of second followed user was incorrect. Got: %s, expected: %s.", following[1].Followee.Name, "josé neves")
+	if following[1].Followee.Name != "RogerTheMovieManiac88" {
+		t.Errorf("Name of second followed user was incorrect. Got: %s, expected: %s.", following[1].Followee.Name, "RogerTheMovieManiac88")
 	}
 }

--- a/testdata/mubi-followers-sample.json
+++ b/testdata/mubi-followers-sample.json
@@ -1,0 +1,602 @@
+[
+  {
+    "id": 6599609,
+    "followee_id": 8803115,
+    "follower_id": 5070807,
+    "created_at": 1623515130,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 5070807,
+      "name": "Ryuu Baron",
+      "canonical_url": "https://mubi.com/users/5070807",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/73878/cache-73878-1614622648/images-large.png?size=150x150",
+      "bio": "i like movies, sort of, but if pictures tell a story i will watch it, either i like it or not, only to see the different aspects of a narrative:mauro.brandao.pt",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/142588/images-small.jpg?1614622752",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6598792,
+    "followee_id": 8803115,
+    "follower_id": 1412806,
+    "created_at": 1622979222,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 1412806,
+      "name": "Filip Klokan",
+      "canonical_url": "https://mubi.com/users/1412806",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/82217/cache-82217-1602848757/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/127031/images-small.jpg?1604507261",
+      "has_payment_method": true,
+      "eligible_for_trial": true,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6596459,
+    "followee_id": 8803115,
+    "follower_id": 21892,
+    "created_at": 1621525600,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 21892,
+      "name": "Severus Snape",
+      "canonical_url": "https://mubi.com/users/21892",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/95948/cache-95948-1620860589/images-large.jpg?size=150x150",
+      "bio": "https://youtu.be/9MaqRpjdptM",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/153948/images-small.jpg?1623608215",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6585425,
+    "followee_id": 8803115,
+    "follower_id": 11015566,
+    "created_at": 1616781916,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 11015566,
+      "name": "MarcoBì",
+      "canonical_url": "https://mubi.com/users/11015566",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/155992/cache-155992-1612616638/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/140921/images-small.jpg?1613396169",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6582015,
+    "followee_id": 8803115,
+    "follower_id": 6765826,
+    "created_at": 1615539322,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6765826,
+      "name": "bernardovazdecastro",
+      "canonical_url": "https://mubi.com/users/6765826",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/101641/cache-101641-1523897989/images-large.jpg?size=150x150",
+      "bio": "Center Stage (1991), Stanley Kwan",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/153536/images-small.jpg?1623234968",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6581907,
+    "followee_id": 8803115,
+    "follower_id": 8802178,
+    "created_at": 1615484464,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 8802178,
+      "name": "Shrekcore",
+      "canonical_url": "https://mubi.com/users/8802178",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/125252/cache-125252-1622320454/images-large.png?size=150x150",
+      "bio": "A thousand Dreams within me softly burn:\nFrom time to time my heart is like some oak\nWhose blood runs golden where a branch is torn. - Rimbaud",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/154621/images-small.png?1624165717",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6581865,
+    "followee_id": 8803115,
+    "follower_id": 259690,
+    "created_at": 1615473278,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 259690,
+      "name": "Danny Bailey",
+      "canonical_url": "https://mubi.com/users/259690",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/18589/cache-18589-1523887341/images-large.jpg?size=150x150",
+      "bio": "Check out my Tumblr blog of film reviews at http://dannyreviews.tumblr.com/",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/125554/images-small.png?1603217871",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6578141,
+    "followee_id": 8803115,
+    "follower_id": 11349916,
+    "created_at": 1614080826,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 11349916,
+      "name": "Satanstango",
+      "canonical_url": "https://mubi.com/users/11349916",
+      "avatar_url": "//mubi.com/assets/placeholders/avatar-2b64b89b674f3bee3279c73763e9588cd01989594c56f2f96da75963e3f41285.png",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": null,
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6575458,
+    "followee_id": 8803115,
+    "follower_id": 1283034,
+    "created_at": 1613141283,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 1283034,
+      "name": "Adam Laurence Pitt",
+      "canonical_url": "https://mubi.com/users/1283034",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/69846/cache-69846-1523894734/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/152800/images-small.jpeg?1622575286",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6574642,
+    "followee_id": 8803115,
+    "follower_id": 6076895,
+    "created_at": 1612777508,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6076895,
+      "name": "Bilouaustria",
+      "canonical_url": "https://mubi.com/users/6076895",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/110322/cache-110322-1523899492/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/46536/images-small.jpg?1457778018",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6572562,
+    "followee_id": 8803115,
+    "follower_id": 9257582,
+    "created_at": 1611815516,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 9257582,
+      "name": "T",
+      "canonical_url": "https://mubi.com/users/9257582",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/130591/cache-130591-1619491713/images-large.png?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/97733/images-small.jpeg?1579621770",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6571710,
+    "followee_id": 8803115,
+    "follower_id": 8300799,
+    "created_at": 1611540406,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 8300799,
+      "name": "Tornasol",
+      "canonical_url": "https://mubi.com/users/8300799",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/117740/cache-117740-1621692844/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/152751/images-small.png?1622519591",
+      "has_payment_method": false,
+      "eligible_for_trial": true,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6571298,
+    "followee_id": 8803115,
+    "follower_id": 7055804,
+    "created_at": 1611413683,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 7055804,
+      "name": "ASHES IN THE HOURGLASS",
+      "canonical_url": "https://mubi.com/users/7055804",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/104004/cache-104004-1523898362/images-large.png?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/50477/images-small.png?1464059262",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6570382,
+    "followee_id": 8803115,
+    "follower_id": 128705,
+    "created_at": 1611011449,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 128705,
+      "name": "Jorge Didaco",
+      "canonical_url": "https://mubi.com/users/128705",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/42936/cache-42936-1309717086/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": null,
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6561023,
+    "followee_id": 8803115,
+    "follower_id": 8710558,
+    "created_at": 1607523487,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 8710558,
+      "name": "Matt R1",
+      "canonical_url": "https://mubi.com/users/8710558",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/123179/cache-123179-1547408383/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/84586/images-small.png?1547656716",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6554727,
+    "followee_id": 8803115,
+    "follower_id": 7708156,
+    "created_at": 1604069408,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 7708156,
+      "name": "Conor McCoy",
+      "canonical_url": "https://mubi.com/users/7708156",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/152109/cache-152109-1604069621/images-large.png?size=150x150",
+      "bio": "misery & hilarity in no particular order",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/126357/images-small.jpg?1604069670",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6551542,
+    "followee_id": 8803115,
+    "follower_id": 9752008,
+    "created_at": 1602175781,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 9752008,
+      "name": "anhedonik",
+      "canonical_url": "https://mubi.com/users/9752008",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/135778/cache-135778-1586627361/images-large.gif?size=150x150",
+      "bio": "* 11. 04. 2020 ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/104515/images-small.gif?1586627286",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6549240,
+    "followee_id": 8803115,
+    "follower_id": 8168391,
+    "created_at": 1600674954,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 8168391,
+      "name": "Dissipatio",
+      "canonical_url": "https://mubi.com/users/8168391",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/116024/cache-116024-1621257259/images-large.png?size=150x150",
+      "bio": "Too late, too early",
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/129764/images-small.png?1607186944",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6546846,
+    "followee_id": 8803115,
+    "follower_id": 6164674,
+    "created_at": 1599424210,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6542363,
+    "followee_id": 8803115,
+    "follower_id": 10139014,
+    "created_at": 1597350946,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 10139014,
+      "name": "Stefan16",
+      "canonical_url": "https://mubi.com/users/10139014",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/164112/cache-164112-1622487742/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/152660/images-small.jpg?1622479089",
+      "has_payment_method": true,
+      "eligible_for_trial": true,
+      "trialist": false
+    }
+  }
+]

--- a/testdata/mubi-following-sample.json
+++ b/testdata/mubi-following-sample.json
@@ -1,40 +1,22 @@
 [
   {
-    "id": 6600683,
-    "followee_id": 10856256,
-    "follower_id": 7995037,
-    "created_at": 1624198972,
+    "id": 6602705,
+    "followee_id": 224774,
+    "follower_id": 6164674,
+    "created_at": 1625664563,
     "followee": {
-      "id": 10856256,
-      "name": "Manuel",
-      "canonical_url": "https://mubi.com/users/10856256",
-      "avatar_url": "//mubi.com/assets/placeholders/avatar-2b64b89b674f3bee3279c73763e9588cd01989594c56f2f96da75963e3f41285.png",
-      "bio": null,
-      "subscriber": true,
-      "cover_image_url": null,
+      "id": 224774,
+      "name": "mubianer",
+      "canonical_url": "https://mubi.com/users/224774",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/92093/cache-92093-1523896799/images-large.png?size=150x150",
+      "bio": "I usually mention the format if it's 16/35/70 mm, as it's becoming a rare experience. Otherwise it's DCP or home viewing. 5 stars = masterpiece.",
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/120853/images-small.jpg?1598400597",
       "has_payment_method": true,
-      "eligible_for_trial": false,
+      "eligible_for_trial": true,
       "trialist": false
     },
     "follower": {
-      "id": 7995037,
-      "name": "jdennes",
-      "canonical_url": "https://mubi.com/users/7995037",
-      "avatar_url": "https://images.mubicdn.net/images/avatars/113982/cache-113982-1523900231/images-large.jpg?size=150x150",
-      "bio": null,
-      "subscriber": false,
-      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/80119/images-small.jpg?1535047013",
-      "has_payment_method": true,
-      "eligible_for_trial": false,
-      "trialist": false
-    }
-  },
-  {
-    "id": 6428178,
-    "followee_id": 6164674,
-    "follower_id": 7995037,
-    "created_at": 1569176369,
-    "followee": {
       "id": 6164674,
       "name": "josé neves",
       "canonical_url": "https://mubi.com/users/6164674",
@@ -45,18 +27,576 @@
       "has_payment_method": false,
       "eligible_for_trial": false,
       "trialist": true
+    }
+  },
+  {
+    "id": 6600393,
+    "followee_id": 7366554,
+    "follower_id": 6164674,
+    "created_at": 1624012518,
+    "followee": {
+      "id": 7366554,
+      "name": "RogerTheMovieManiac88",
+      "canonical_url": "https://mubi.com/users/7366554",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/211533/cache-211533-1620942055/images-large.jpeg?size=150x150",
+      "bio": "Film fan... Born 1988... From Westmeath in the midlands of Ireland. Always interested in widening and extending my cinematic horizons.",
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/123017/images-small.jpg?1600289806",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": false
     },
     "follower": {
-      "id": 7995037,
-      "name": "jdennes",
-      "canonical_url": "https://mubi.com/users/7995037",
-      "avatar_url": "https://images.mubicdn.net/images/avatars/113982/cache-113982-1523900231/images-large.jpg?size=150x150",
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6598222,
+    "followee_id": 6807173,
+    "follower_id": 6164674,
+    "created_at": 1622622579,
+    "followee": {
+      "id": 6807173,
+      "name": "dr0nestar",
+      "canonical_url": "https://mubi.com/users/6807173",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/104528/cache-104528-1523898438/images-large.jpg?size=150x150",
       "bio": null,
       "subscriber": false,
-      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/80119/images-small.jpg?1535047013",
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/27976/images-small.jpg?1427835156",
       "has_payment_method": true,
       "eligible_for_trial": false,
       "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6597638,
+    "followee_id": 5554166,
+    "follower_id": 6164674,
+    "created_at": 1622230394,
+    "followee": {
+      "id": 5554166,
+      "name": "Sergei Dyoshin",
+      "canonical_url": "https://mubi.com/users/5554166",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/195615/cache-195615-1623145600/images-large.jpeg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/45500/images-small.png?1456170756",
+      "has_payment_method": false,
+      "eligible_for_trial": true,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6594092,
+    "followee_id": 10133522,
+    "follower_id": 6164674,
+    "created_at": 1620204528,
+    "followee": {
+      "id": 10133522,
+      "name": "Jigsaw Feeling",
+      "canonical_url": "https://mubi.com/users/10133522",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/144469/cache-144469-1615160978/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/143304/images-small.jpg?1615161255",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6593082,
+    "followee_id": 9715532,
+    "follower_id": 6164674,
+    "created_at": 1619770657,
+    "followee": {
+      "id": 9715532,
+      "name": "Saeed Bidar Kahnamuie",
+      "canonical_url": "https://mubi.com/users/9715532",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/285891/cache-285891-1625576204/images-large.jpeg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/125003/images-small.jpg?1602513783",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6585570,
+    "followee_id": 7848206,
+    "follower_id": 6164674,
+    "created_at": 1616836623,
+    "followee": {
+      "id": 7848206,
+      "name": "Jorge Olaya",
+      "canonical_url": "https://mubi.com/users/7848206",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/126492/cache-126492-1563707804/images-large.jpg?size=150x150",
+      "bio": "#SOSColombia",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/150519/images-small.jpg?1620672665",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6583542,
+    "followee_id": 7840977,
+    "follower_id": 6164674,
+    "created_at": 1616005047,
+    "followee": {
+      "id": 7840977,
+      "name": "Leon Blank",
+      "canonical_url": "https://mubi.com/users/7840977",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/124333/cache-124333-1552744918/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86881/images-small.jpg?1552745037",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6581271,
+    "followee_id": 56483,
+    "follower_id": 6164674,
+    "created_at": 1615159223,
+    "followee": {
+      "id": 56483,
+      "name": "Jose Sarmiento Hinojosa",
+      "canonical_url": "https://mubi.com/users/56483",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/61370/cache-61370-1523893808/images-large.gif?size=150x150",
+      "bio": "@desistfilm Director. Film critic/curator, programmer @MUTA.",
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/15692/images-small.jpg?1411341419",
+      "has_payment_method": true,
+      "eligible_for_trial": true,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6579643,
+    "followee_id": 8802178,
+    "follower_id": 6164674,
+    "created_at": 1614541370,
+    "followee": {
+      "id": 8802178,
+      "name": "Shrekcore",
+      "canonical_url": "https://mubi.com/users/8802178",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/125252/cache-125252-1622320454/images-large.png?size=150x150",
+      "bio": "A thousand Dreams within me softly burn:\nFrom time to time my heart is like some oak\nWhose blood runs golden where a branch is torn. - Rimbaud",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/154621/images-small.png?1624165717",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6579269,
+    "followee_id": 7194393,
+    "follower_id": 6164674,
+    "created_at": 1614382475,
+    "followee": {
+      "id": 7194393,
+      "name": "Yorkie Blue",
+      "canonical_url": "https://mubi.com/users/7194393",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/122281/cache-122281-1579976820/images-large.JPG?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/82958/images-small.jpg?1544126634",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6578021,
+    "followee_id": 6076895,
+    "follower_id": 6164674,
+    "created_at": 1614036846,
+    "followee": {
+      "id": 6076895,
+      "name": "Bilouaustria",
+      "canonical_url": "https://mubi.com/users/6076895",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/110322/cache-110322-1523899492/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/46536/images-small.jpg?1457778018",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6576366,
+    "followee_id": 7356586,
+    "follower_id": 6164674,
+    "created_at": 1613409506,
+    "followee": {
+      "id": 7356586,
+      "name": "sunset baudelard",
+      "canonical_url": "https://mubi.com/users/7356586",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/159982/cache-159982-1617047334/images-large.png?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/149874/images-small.png?1620150150",
+      "has_payment_method": false,
+      "eligible_for_trial": true,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6574693,
+    "followee_id": 4957641,
+    "follower_id": 6164674,
+    "created_at": 1612792195,
+    "followee": {
+      "id": 4957641,
+      "name": "Sina Habibi",
+      "canonical_url": "https://mubi.com/users/4957641",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/122570/cache-122570-1571938637/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/83740/images-small.jpg?1546030650",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6573153,
+    "followee_id": 6911865,
+    "follower_id": 6164674,
+    "created_at": 1612096506,
+    "followee": {
+      "id": 6911865,
+      "name": "Ruiz Buñuel",
+      "canonical_url": "https://mubi.com/users/6911865",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/102825/cache-102825-1523898174/images-large.png?size=150x150",
+      "bio": "Ruiz on KG, no English subs: Medee, Litoral, Edipo, Ahora te vamos a llamar hermano, Petit manuel d'historie de France, Cofralandes I-IV, Edipo, Dias de campo",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/69963/images-small.jpg?1508006006",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6573068,
+    "followee_id": 6538422,
+    "follower_id": 6164674,
+    "created_at": 1612050894,
+    "followee": {
+      "id": 6538422,
+      "name": "Mihai Cristea",
+      "canonical_url": "https://mubi.com/users/6538422",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/98616/cache-98616-1524244020/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/98146/images-small.jpg?1580289917",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6568143,
+    "followee_id": 8817105,
+    "follower_id": 6164674,
+    "created_at": 1610315435,
+    "followee": {
+      "id": 8817105,
+      "name": "thebaus",
+      "canonical_url": "https://mubi.com/users/8817105",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/126268/cache-126268-1562587123/images-large.png?size=150x150",
+      "bio": "Our world, like a charnel-house, lies strewn with the detritus of dead epochs.",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/127138/images-small.png?1604614735",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6565380,
+    "followee_id": 6779491,
+    "follower_id": 6164674,
+    "created_at": 1609540876,
+    "followee": {
+      "id": 6779491,
+      "name": "Aydin KhaliliK",
+      "canonical_url": "https://mubi.com/users/6779491",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/102175/cache-102175-1595262386/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/112902/images-small.jpg?1591508459",
+      "has_payment_method": false,
+      "eligible_for_trial": true,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6561466,
+    "followee_id": 8300799,
+    "follower_id": 6164674,
+    "created_at": 1607770720,
+    "followee": {
+      "id": 8300799,
+      "name": "Tornasol",
+      "canonical_url": "https://mubi.com/users/8300799",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/117740/cache-117740-1621692844/images-large.jpg?size=150x150",
+      "bio": null,
+      "subscriber": false,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/152751/images-small.png?1622519591",
+      "has_payment_method": false,
+      "eligible_for_trial": true,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
+    }
+  },
+  {
+    "id": 6546846,
+    "followee_id": 8803115,
+    "follower_id": 6164674,
+    "created_at": 1599424210,
+    "followee": {
+      "id": 8803115,
+      "name": "Jerro",
+      "canonical_url": "https://mubi.com/users/8803115",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/131095/cache-131095-1619367848/images-large.jpg?size=150x150",
+      "bio": "\"Everyday give yourself a movie.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/148803/images-small.jpg?1619367626",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    },
+    "follower": {
+      "id": 6164674,
+      "name": "josé neves",
+      "canonical_url": "https://mubi.com/users/6164674",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/99745/cache-99745-1599132358/images-large.png?size=150x150",
+      "bio": "\"There was a boy/A very strange enchanted boy\"They say he wandered/very far, very far/Over land and sea/A little shy and sad of eye/But very wise was he.\"",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/155375/images-small.png?1624958130",
+      "has_payment_method": false,
+      "eligible_for_trial": false,
+      "trialist": true
     }
   }
 ]


### PR DESCRIPTION
Similar to https://github.com/jdennes/mubi/pull/6, but getting a user's followers instead of who they're following.

Can be used like:

```go
package main

import (
	"github.com/jdennes/mubi"
)

func main() {
	api := mubi.NewMubiAPI()
	userId, page, perPage := int64(7995037), 1, 20
	followers := api.GetFollowers(userId, page, perPage)
	// etc
}
```

Example command implemented:

```
$ mubi followers --userid 6164674
Atefe - https://mubi.com/users/8819661
Bio: 
Followed on 2021-07-08 14:16:19 +0200 CEST
-----
MAT - https://mubi.com/users/11706732
Bio: mateocc
Followed on 2021-07-08 08:48:59 +0200 CEST
-----
Davi Dantas - https://mubi.com/users/8196670
Bio: A film school dropper. Happy though :)
Followed on 2021-07-07 19:59:34 +0200 CEST
-----
Al - https://mubi.com/users/11031631
Bio: 
Followed on 2021-07-05 10:41:02 +0200 CEST
-----
...
```