### PR TITLE
Support getting a user's lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently supported things being:
 - Get a user's film ratings (https://mubi.com/users/:id)
 - Get a user's watchlist (https://mubi.com/users/:id/watchlist)
 - Get a user's favourite films (https://mubi.com/users/:id/favourites)
+- Get a user's lists (https://mubi.com/users/:id/lists)
 - Get the users a user is following (https://mubi.com/users/:id/following)
 - Get a user's followers (https://mubi.com/users/:id/followers)
 - Get the current list of films of the day (https://mubi.com/film-of-the-day)

--- a/cmd/mubi/main.go
+++ b/cmd/mubi/main.go
@@ -175,7 +175,7 @@ func printLists(api mubi.MubiAPI, userId int64, page int, perPage int) {
 		}
 		fmt.Printf("%s (%d %s) - %s\n", list.Title, list.ListFilmsCount, filmPlural, list.CanonicalUrl)
 		createdAt := time.Unix(list.CreatedAt, 0)
-		updatedAt := time.Unix(list.CreatedAt, 0)
+		updatedAt := time.Unix(list.UpdatedAt, 0)
 		fmt.Printf("Created on %s\n", createdAt)
 		fmt.Printf("Updated on %s\n", updatedAt)
 		fmt.Printf("-----\n")

--- a/lists.go
+++ b/lists.go
@@ -1,0 +1,32 @@
+package mubi
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+type List struct {
+	Id             int    `json:id`
+	Title          string `json:title`
+	ListFilmsCount int    `json:"list_films_count"`
+	CreatedAt      int64  `json:"created_at"`
+	UpdatedAt      int64  `json:"updated_at"`
+	CanonicalUrl   string `json:"canonical_url"`
+}
+
+func (api *MubiAPI) GetLists(userId int64, page int, perPage int) []List {
+	url := fmt.Sprintf(
+		"https://mubi.com/services/api/lists?user_id=%d&sort=updated_at&page=%d&per_page=%d",
+		userId, page, perPage,
+	)
+
+	body := api.GetResponseBody(url)
+	lists := make([]List, 0)
+	jsonErr := json.Unmarshal(body, &lists)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return lists
+}

--- a/lists_test.go
+++ b/lists_test.go
@@ -1,0 +1,35 @@
+package mubi
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestGetLists(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		file, _ := os.Open("testdata/mubi-lists-sample.json")
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(file),
+			Header:     make(http.Header),
+		}
+	})
+
+	api := MubiAPI{client}
+	userId, page, perPage := int64(56195), 1, 20
+	lists := api.GetLists(userId, page, perPage)
+
+	if len(lists) != 20 {
+		t.Errorf("Number of lists was incorrect. Got: %d, expected: %d.", len(lists), 20)
+	}
+
+	if lists[0].Title != "100 DIRECTORS' ESSENTIAL FILMS" {
+		t.Errorf("Title of first list was incorrect. Got: %s, expected: %s.", lists[0].Title, "100 DIRECTORS' ESSENTIAL FILMS")
+	}
+
+	if lists[1].Title != "MY FAVOURITE FILMS BY WOMEN" {
+		t.Errorf("Title of second list user was incorrect. Got: %s, expected: %s.", lists[1].Title, "MY FAVOURITE FILMS BY WOMEN")
+	}
+}

--- a/testdata/mubi-lists-sample.json
+++ b/testdata/mubi-lists-sample.json
@@ -1,0 +1,722 @@
+[
+  {
+    "id": 5512,
+    "user_id": 56195,
+    "title": "100 DIRECTORS' ESSENTIAL FILMS",
+    "list_films_count": 673,
+    "updated_at": 1625932957,
+    "created_at": 1267791852,
+    "canonical_url": "https://mubi.com/lists/101-directors-essential-films",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/5512/image-large.jpg?1600842206",
+      "medium": "https://assets.mubicdn.net/images/list/5512/image-medium.jpg?1600842206",
+      "small": "https://assets.mubicdn.net/images/list/5512/image-small.jpg?1600842206",
+      "square": "https://assets.mubicdn.net/images/list/5512/image-w140.jpg?1600842206"
+    },
+    "fanship_count": 10138,
+    "comment_count": 66,
+    "description": "<p>Do click on Read More and the links. Thanks to all following this surprisingly popular list of important, critically admired and well known directors. A pantheon first, alphabetically from Bergman to Welles, the rest in changing order. And a few personal wild cards. Of course in time more women will be included (the only two so far are both from Belgium, land of my heroine Andrée Dumon). Modern directors will be more prominent too, and I expect more from Latin America, neglected countries and regions.</p>\n<p>Anyway, the 100 are:</p>\n<p>Akerman<br>\nAllen<br>\nAlmodovar<br>\nAltman<br>\nAnderson (P.T)<br>\nAnderson (W)<br>\nAngelopoulos<br>\nAntonioni<br>\nBergman<br>\nBertolucci<br>\nBong<br>\nBresson<br>\nBunuel<br>\nCameron<br>\nCapra<br>\nCassavetes<br>\nCeylan<br>\nChaplin<br>\nCoen bros<br>\nCoppola<br>\nCukor<br>\nDe Sica<br>\nDiaz<br>\nDreyer<br>\nEisenstein<br>\nFassbinder<br>\nFellini<br>\nFord<br>\nGodard<br>\nGriffith<br>\nHaneke<br>\nHawks<br>\nHerzog<br>\nHitchcock<br>\nHou<br>\nHuston<br>\nImamura<br>\nKeaton<br>\nKiarostami<br>\nKieslowski<br>\nKobayashi<br>\nKore-eda<br>\nKubrick<br>\nKurosawa<br>\nLang<br>\nLean<br>\nLee (Spike)<br>\nLeone<br>\nLoach<br>\nLubitsch<br>\nLumet<br>\nLynch<br>\nMalick<br>\nMalle<br>\nMarker<br>\nMelville<br>\nMiyazaki<br>\nMizoguchi<br>\nMonteiro<br>\nMurnau<br>\nNaruse<br>\nNolan<br>\nOliveira<br>\nOphuls<br>\nOzu<br>\nPasolini<br>\nPilger<br>\nPolanski<br>\nPowell<br>\nRay (N)<br>\nRay (S)<br>\nRenoir<br>\nResnais<br>\nRivette<br>\nRohmer<br>\nRossellini<br>\nRuiz<br>\nScorsese<br>\nScott<br>\nSembene<br>\nSpielberg<br>\nSternberg<br>\nTarantino<br>\nTarkovsky<br>\nTarr<br>\nTourneur<br>\nTruffaut<br>\nVarda<br>\nVertov<br>\nVisconti<br>\nVon Trier<br>\nWeerasethakul<br>\nWelles<br>\nWenders<br>\nWilder<br>\nWiseman<br>\nWong<br>\nWyler<br>\nYang<br>\nZhang</p>\n<p>Bubbling under: Argento, Borzage, Brakhage, Burns, Burton, Campion, Carné,, Cissé, Clair, Clouzot, Cocteau, Cronenberg, Cuaron, Curtiz, Dang, Dardenne bros, Demy, Denis,  De Palma, Eastwood,, Erice, Farhadi, Feuillade, Fincher, Forman, Gerima, Ghatak, Greenaway, Guney, Hong, Ichikawa, Inarritu, Iosseliani, Ivens, Jackson, Jancso, Jarmusch, Jia, Chuck Jones, Jude, Kaul, Kaurismaki, Kawase, Kazan, Kitano, Robert Kramer, Leigh, Linklater, Martel, McQueen, Mekas, Mendes, Minnelli, Olmi, Marcel Ophuls, Oshima, Paradjanov, Peck, Peckinpah, Peries, Reed, Rocha, Sanjines, Sciamma, Mrinal .Sen, Shimizu, Sirk, Sjostrom, Sokurov, Stone, Preston Sturges, Tati, Tsai, Vidor, Vigo, Villeneuve, Vlacil, Von Stroheim, Wajda, Yoshida, Zanussi, Zinnemann, Zulawski….</p>\n<p>The Life of an Actor and A Woman of Osaka, regarded at the time as among Mizoguchi’s finest, are lost.</p>\n<p>See also my lists <br>\n<a href=\"https://mubi.com/lists/500-directors\" rel=\"nofollow\">Directors A-Z</a> ,<br>\n<a href=\"http://mubi.com/lists/essential-films-by-women\" rel=\"nofollow\">Essential Films by Women: A Canon</a>,<br>\n<a href=\"http://mubi.com/lists/Notable-Films-by-Black-Directors\" rel=\"nofollow\">Notable Films by Black Directors</a>, <br>\n<a href=\"https://mubi.com/lists/japanese-directors-a-selection\" rel=\"nofollow\">Japanese Directors</a>, and<br>\n<a href=\"https://mubi.com/lists/films-by-welsh-directors-a-selection\" rel=\"nofollow\">by Welsh directors</a>.</p>\n<p>and on individual directors:</p>\n<p><a href=\"http://mubi.com/lists/4775\" rel=\"nofollow\">Mizoguchi Revered</a><br>\n<a href=\"http://mubi.com/lists/directors-round-mizoguchi\" rel=\"nofollow\">Directors Round Mizoguchi</a><br>\n<a href=\"http://mubi.com/lists/tarkovskys-legacy\" rel=\"nofollow\">Tarkovsky’s Legacy</a><br>\n<a href=\"http://mubi.com/lists/films-admired-by-tarkovsky\" rel=\"nofollow\">Films Admired by Tarkovsky</a><br>\n<a href=\"http://mubi.com/lists/satyajit-ray--3\" rel=\"nofollow\">Satyajit Ray</a><br>\n<a href=\"http://mubi.com/lists/le-cinema-cest-jean-renoir\" rel=\"nofollow\">Le Cinéma, c’est Jean Renoir</a><br>\n<a href=\"http://mubi.com/lists/essential-hitchcock\" rel=\"nofollow\">Essential Hitchcock</a><br>\n<a href=\"http://mubi.com/lists/essential-kubrick\" rel=\"nofollow\">Essential Kubrick</a><br>\n<a href=\"https://mubi.com/lists/essential-godard--2\" rel=\"nofollow\">Essential Godard</a><br>\n<a href=\"https://mubi.com/lists/the-essential-bergman\" rel=\"nofollow\">Essential Bergman</a><br>\n<a href=\"https://mubi.com/lists/the-essential-bunuel\" rel=\"nofollow\">Essential Bunuel</a><br>\n<a href=\"https://mubi.com/lists/the-great-lester-james-peries\" rel=\"nofollow\">Lester James Peries, hidden master</a><br>\n<a href=\"https://mubi.com/lists/yoshida\" rel=\"nofollow\">Yoshida</a><br>\n<a href=\"https://mubi.com/lists/eric-rohmer--3\" rel=\"nofollow\">Eric Rohmer</a><br>\n<a href=\"https://mubi.com/lists/the-greatest-living-directors\" rel=\"nofollow\">John Pilger</a><br>\n<a href=\"https://mubi.com/lists/ruiz\" rel=\"nofollow\">The Liberation of Raul Ruiz</a><br>\n<a href=\"https://mubi.com/lists/joris-ivens\" rel=\"nofollow\">Joris Ivens</a><br>\n<a href=\"https://mubi.com/lists/shadowy-whispers-the-wonderful-world-of-the-brothers-quay\" rel=\"nofollow\">Quay brothers</a><br>\n<a href=\"https://mubi.com/lists/the-essential-agnes-varda\" rel=\"nofollow\">The Essential Agnes Varda</a><br>\n<a href=\"http://mubi.com/lists/12426\" rel=\"nofollow\">Alice Guy-Blaché, Queen of the Pioneers</a><br>\n<a href=\"https://mubi.com/lists/the-best-of-wim-wenders\" rel=\"nofollow\">The Best of Wim Wenders</a><br>\n<a href=\"https://mubi.com/lists/gaston-kabore\" rel=\"nofollow\">Gaston Kaboré</a><br>\n<a href=\"https://mubi.com/lists/greenaway-a-z\" rel=\"nofollow\">Greenaway A-Z</a></p>\n<p>~</p>\n<p>My favourite list-maker on Mubi is Apursansar, who is extremely knowledgeable and always up on recent films from round the world, and an expert on Latin American, Indian and German films in particular. Mario Gaborovic has done excellent lists on Balkans countries.</p>\n<p>Some other lists I’ve done:</p>\n<p><a href=\"http://mubi.com/lists/kenjis-japanese-canon\" rel=\"nofollow\">Essential Japanese Films</a> ,<br>\n<a href=\"https://mubi.com/lists/kenjis-canon-the-big-1000\" rel=\"nofollow\">Kenji’s 1000</a> ,<br>\n<a href=\"http://mubi.com/lists/19805\" rel=\"nofollow\">The Labyrinth</a> ,<br>\n<a href=\"http://mubi.com/lists/973\" rel=\"nofollow\">The Mubi/Auteurs World Cup Films</a> ,<br>\n<a href=\"http://mubi.com/lists/the-welsh-connection\" rel=\"nofollow\">The Welsh Connection</a> ,<br>\n<a href=\"https://mubi.com/lists/let-there-be-light-the-birth-of-films-to-1899\" rel=\"nofollow\">Let There be Light: The Birth of Films</a> ,<br>\n<a href=\"https://mubi.com/lists/essayists-diarists-musersfunambulists-of-free-thought\" rel=\"nofollow\">Essayists, Diarists, Musers..Funambulists of Free Thought</a> , <br>\n<a href=\"http://mubi.com/lists/7258\" rel=\"nofollow\">A Rosefinch Sang: the Czechoslovakian New Wave</a> ,<br>\n<a href=\"http://mubi.com/lists/19th-century-britain\" rel=\"nofollow\">19th Century Britain</a> ,<br>\n<a href=\"http://mubi.com/lists/essential-french-films\" rel=\"nofollow\">Essential French Films</a> ,<br>\n<a href=\"http://mubi.com/lists/Essential-African-Films\" rel=\"nofollow\">Essential African Films</a> ,<br>\n<a href=\"https://mubi.com/lists/portugal-land-of-my-dreams\" rel=\"nofollow\">Portugal, Land of My Dreams</a> ,<br>\n<a href=\"http://mubi.com/lists/they-do-not-exist-palestine\" rel=\"nofollow\">They Do Not Exist: Palestine</a> ,<br>\n<a href=\"https://mubi.com/lists/lesotho\" rel=\"nofollow\">We Love Lesotho</a> ,<br>\n<a href=\"https://mubi.com/lists/favourite-indian-films\" rel=\"nofollow\">India</a> ,<br>\n<a href=\"https://mubi.com/lists/essential-iranian-films\" rel=\"nofollow\">Essential Iranian Films</a> ,<br>\n<a href=\"https://mubi.com/lists/101-favourite-documentaries\" rel=\"nofollow\">Essential Documentaries</a> ,<br>\n<a href=\"http://mubi.com/lists/favourite-short-films\" rel=\"nofollow\">Essential Short Films &amp; Featurettes</a> ,<br>\n<a href=\"https://mubi.com/lists/favourite-animations\" rel=\"nofollow\">Essential Animation</a> ,<br>\n<a href=\"http://mubi.com/lists/hidden-treasures\" rel=\"nofollow\">Hidden Treasures</a> ,<br>\n<a href=\"https://mubi.com/lists/leftist-films\" rel=\"nofollow\">Leftist Films</a> ,<br>\n<a href=\"https://mubi.com/lists/great-cinematographers\" rel=\"nofollow\">Great Cinematographers</a> ,<br>\n<a href=\"https://mubi.com/lists/my-101-favourite-films\" rel=\"nofollow\">Favourite Films</a> ,<br>\n<a href=\"https://mubi.com/lists/kenjis-poetry-anthology-part-1\" rel=\"nofollow\">Kenji’s Poetry Anthology 1</a> ,<br>\n<a href=\"https://mubi.com/lists/kenjis-poetry-anthology-part-2\" rel=\"nofollow\">Kenji’s Poetry Anthology 2</a></p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/173/image-w320.jpg?1558111471",
+      "https://assets.mubicdn.net/images/film/175/image-w320.jpg?1608829074",
+      "https://assets.mubicdn.net/images/film/372/image-w320.jpg?1558598540"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 30323,
+    "user_id": 56195,
+    "title": "MY FAVOURITE FILMS BY WOMEN",
+    "list_films_count": 41,
+    "updated_at": 1625928729,
+    "created_at": 1309429999,
+    "canonical_url": "https://mubi.com/lists/my-favourite-films-by-women",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/film/224497/image-w1280.jpg?1582022611",
+      "medium": "https://assets.mubicdn.net/images/film/224497/image-w384.jpg?1582022611",
+      "small": "https://assets.mubicdn.net/images/film/224497/image-w128.jpg?1582022611",
+      "square": "https://assets.mubicdn.net/images/film/224497/image-w140.jpg?1582022611"
+    },
+    "fanship_count": 39,
+    "comment_count": 3,
+    "description": "<p>This is just a little offshoot to my list <a href=\"http://mubi.com/lists/essential-films-by-women\" rel=\"nofollow\">Essential Films by Women: A Canon</a></p>\n<p>I’m including some TV and films with male co-directors.</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/224497/image-w320.jpg?1582022611",
+      "https://assets.mubicdn.net/images/film/224259/image-w320.jpg?1607375540",
+      "https://assets.mubicdn.net/images/film/29826/image-w320.jpg?1445875734"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 7047,
+    "user_id": 56195,
+    "title": "ÉRIC ROHMER's LEGACY",
+    "list_films_count": 77,
+    "updated_at": 1625922150,
+    "created_at": 1270646180,
+    "canonical_url": "https://mubi.com/lists/eric-rohmer--3",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/7047/image-large.jpg?1610883474",
+      "medium": "https://assets.mubicdn.net/images/list/7047/image-medium.jpg?1610883474",
+      "small": "https://assets.mubicdn.net/images/list/7047/image-small.jpg?1610883474",
+      "square": "https://assets.mubicdn.net/images/list/7047/image-w140.jpg?1610883474"
+    },
+    "fanship_count": 126,
+    "comment_count": 7,
+    "description": "<p>Click on the links. <a href=\"http://circeo59.files.wordpress.com/2011/02/le-rayon-vert-13.jpg\" rel=\"nofollow\">The Green Ray</a></p>\n<p>“<strong>The most thematically and stylistically consistent investigator of human desire in cinema history</strong>” (Geoff Andrew)</p>\n<p>—</p>\n<p><strong>My favourites</strong>:</p>\n<p><strong>The Green Ray</strong>,<br>\n<strong>Claire’s Knee</strong>,<br>\n<strong>My Night with Maud</strong>,<br>\n<strong>My Girlfriend’s Boyfriend</strong>.</p>\n<p>Rohmer was so consistent that there’s not much to choose between the rest of the features- Le Signe du Lion the first. The list, including various less well known shorts, is in chronological order. His final film was The Romance of Astrée and Celadon; after that i’ve listed tributes and films by other directors with Rohmeresque qualities, including Charlotte and Veronique which he scripted for Godard.</p>\n<p>—</p>\n<p>Rohmer was as dextrous as an expert spider, weaving tales as light as gossamer. As a film-maker he was also a gardener, a lover of nature, a careful tender of young plants, yet happy to allow the freedom to grow and wander too (improvisation in The Green Ray adds to its natural yet magical reality); master of colour and the seasons, and in summer especially the results are glorious.</p>\n<p>A philosopher, muser on fate, free will, temptation and moral choices, ever youthful in spirit, eager to follow his own path and yet able to spring daring surprises to the end. Who else in France these days would have shown the Revolution from the point of view of the Aristocrats? Which film is like Romance of Astrea and Celadon, a tale of young love’s misunderstandings in the time of the druids, seen from the pastoral courtly perspective of a 16th century novelist? Here we have a combination of his trademark young relationships and something of the stylisation of his occasional period films- he appears as much at ease with ages of enlightenment, chivalry and Limbourg brothers’ paintings, e.g <a href=\"https://uploads6.wikiart.org/images/limbourg-brothers/september.jpg\" rel=\"nofollow\">here</a> as the modern era.</p>\n<p>A Catholic, looking down now from a better place. A gallant courtly knight, with a romantic soul to match his intellect and a healthy interest in and respect for women; they are worth getting to know and care about. A lover of the sensuous too; more eroticism in a knee being caressed than any amount of Hollywood grunting and grandstanding. As Gilbert Adair has pointed out, his scripts are much more sophisticated than his characters’ dialogue. And as Geoff Andrew says, Rohmer “exposes the frailty of intention and the erroneous vanity of self-image”. His characters have their foibles- their proclamations and babbling often undercut by their actions or the reality we know better than they- but few are judged harshly, as his observational style has an underlying warmth.</p>\n<p>Rohmer’s films are more cinematic than often credited- the dialogue an extra layer or counterpoint  to what he shows visually, as well as a vehicle for the expression of ideas. And he was acutely attuned to the sounds of nature and the street, to the small gestures, glances and details in relationships. See his films alongside Guerin’s In the City of Sylvia which has been widely praised as pure and cinematic, and which even before i saw The Baker Girl of Monceau, i could see was indebted to Rohmer.</p>\n<p>A modest man, of wide-ranging abilities (novelist and teacher too), content not to broadcast himself with an ego-boosting megaphone, but quietly- so quietly that apparently his own mother was unaware he was a world famous director (he did change his name for that role). In his 1951 short Charlotte et son Steak, not released till 1960, you can see the New Wave coming. He was the mature quiet man of the Nouvelle Vague, and before that a crucial figure in the history of film criticism, editor of the still influential Cahiers du Cinéma as it challenged the world order.</p>\n<p><sub>~</sub>~</p>\n<p><a href=\"http://media.timeout.com/images/resizeBestFit/63517/660/370/image.jpg\" rel=\"nofollow\">My Night at Maud’s</a></p>\n<p><sub>~</sub>~</p>\n<p>Rohmer’s 10 favourite films in 1962:</p>\n<p>True Heart Susie<br>\nThe General<br>\nSunrise<br>\nRules of the Game<br>\nIvan the Terrible<br>\nVoyage to Italy<br>\nRed River<br>\nVertigo<br>\nPickpocket<br>\nLa Pyramide Humaine</p>\n<p>—~</p>\n<p><a href=\"http://www.sensesofcinema.com/2003/great-%E2%80%8Bdirectors/rohmer/\" rel=\"nofollow\">SENSES OF CINEMA ARTICLE</a></p>\n<p><a href=\"http://mubi.com/notebook/posts/close-up-on-eric-rohmers-the-green-ray-an-interview-with-marie-riviere#comment-15858\" rel=\"nofollow\">MUBI INTERVIEW WITH MARIE RIVIERE, ON THE GREEN RAY</a></p>\n<p><a href=\"http://medias.unifrance.org/medias/0/120/30720/format_page/stephanie-crayencour-the-romance-of-astrea-and-celadon.jpg\" rel=\"nofollow\">The Romance of Astrea and Celadon</a></p>\n<p>~</p>\n<p>Kuxa Kanema has conducted a June 2013 poll of mubi users’ Rohmer favourites, and these were the results:</p>\n<p>1.My Night at Maud’s 103 pts<br>\n2.Claire’s Knee, 83<br>\n3.The Green Ray, 73<br>\n4.La Collectionneuse, 53<br>\n5.Love In the Afternoon, 51<br>\n6=.Pauline At the Beach, 47<br>\nThe Aviator’s Wife, 47<br>\n8. My Girlfriend’s Boyfriend, 29<br>\n9.Perceval Le Gallois, 25<br>\n10,Marquise of O, 24<br>\n+ <br>\nThe Four Adventures of Reinette and Mirabelle, 23<br>\nAn Autumn Tale, 19<br>\nA Summer’s Tale, 18<br>\nA Winter’s tale, 18<br>\nThe Romance of Astrea and Celadon, 15<br>\nThe Triple Agent, 14<br>\nFull Moon In Paris, 13<br>\nSuzanne’s Career, 11<br>\nA Tale of Springtime, 10<br>\nThe Bakery Girl of Monceau, 9<br>\nRendez-vous In Paris, 7<br>\nThe Tree, The Mayor and the Mediatheque, 4<br>\nThe Good Marriage, 4<br>\nLady and the Duke, 3<br>\nLe Signe du Lion, 2<br>\nNadja in Paris, 1</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/38045/image-w320.jpg?1611235953",
+      "https://assets.mubicdn.net/images/film/115584/image-w320.jpg?1606325087",
+      "https://assets.mubicdn.net/images/film/117380/image-w320.jpg?1607087090"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 160,
+    "user_id": 56195,
+    "title": "ESSENTIAL IRANIAN FILMS",
+    "list_films_count": 112,
+    "updated_at": 1625916034,
+    "created_at": 1257968674,
+    "canonical_url": "https://mubi.com/lists/essential-iranian-films",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/160/image-large.jpg?1618502420",
+      "medium": "https://assets.mubicdn.net/images/list/160/image-medium.jpg?1618502420",
+      "small": "https://assets.mubicdn.net/images/list/160/image-small.jpg?1618502420",
+      "square": "https://assets.mubicdn.net/images/list/160/image-w140.jpg?1618502420"
+    },
+    "fanship_count": 1203,
+    "comment_count": 35,
+    "description": "<p>Iran has given us one of the world’s great civilisations and a noble cinema too, many films of humanity and intelligence. Common themes include children, the role of women and- in the case of the most critically admired director Kiarostami in particular-, film-making itself and the boundary of illusion and reality. I’m not including films by the Iranian-born Barbet Schroeder but i am including some films on Iranian subjects by Iranian directors working elsewhere.</p>\n<p><strong>Reading</strong>:<br>\n<strong>Mehrnaz Saeed-Vafa, Jonathan Rosenbaum: Abbas Kiarostami</strong><br>\n<strong>Hamid Dabashi: Close Up: Iranian Cinema, Past, Present and Future</strong><br>\n<strong>Hamid Dabashi: Masters and Masterpieces of Iranian Cinema</strong></p>\n<p><a href=\"http://en.wikipedia.org/wiki/Cinema_of_Iran\" rel=\"nofollow\">Wikipedia: Cinema of Iran</a><br>\n<a href=\"http://en.wikipedia.org/wiki/Abbas_Kiarostami\" rel=\"nofollow\">Wikipedia: Abbas Kiarostami</a></p>\n<p><sub>~</sub></p>\n<p>There have been numerous female directors, including some of the most prominent  overall; Forough Farrokhzad, Rakshan Bani-Etemad, Samira and Hana Makhmalbaf, Marzieh Meshkini/Makhmalbaf, Sadaf Foroughi…. and also Marjane Satrapi, Shirin Neshat, Ziba Mir-Hosseini and Mehrnaz Saeed-Vafa based abroad, whose Iranian-set films i’m including in this list.</p>\n<p>The list below is in year order, and i’ve included a few major films i’ve yet to see.</p>\n<p>My favourites:<br>\nThrough the Olive Trees, Gabbeh, And Life Goes On, Brick and Mirror, Close Up, The White Balloon, Bashu the Little Stranger, Taxi, Fireworks Wednesday.</p>\n<p>See also Arsaib’s excellent list <a href=\"http://mubi.com/lists/Sohrab-Shahid-Saless\" rel=\"nofollow\">Sohrab Shahid Saless</a> about the Iranian director who went on to make radical films in West Germany but who has never received due attention either in that country or in general studies internationally of Iranian cinema.</p>\n<p>Oh and do read My Uncle Napoleon, one of my favourite novels.</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/2972/image-w320.jpg?1578961520",
+      "https://assets.mubicdn.net/images/film/24399/image-w320.jpg?1552478529",
+      "https://assets.mubicdn.net/images/film/2272/image-w320.jpg?1581454685"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 234911,
+    "user_id": 56195,
+    "title": "2019, A STRONG YEAR",
+    "list_films_count": 18,
+    "updated_at": 1625913371,
+    "created_at": 1615699232,
+    "canonical_url": "https://mubi.com/lists/2019-20-c533bb25-af59-41f9-90df-bb97d69c5166",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/film/224497/image-w1280.jpg?1582022611",
+      "medium": "https://assets.mubicdn.net/images/film/224497/image-w384.jpg?1582022611",
+      "small": "https://assets.mubicdn.net/images/film/224497/image-w128.jpg?1582022611",
+      "square": "https://assets.mubicdn.net/images/film/224497/image-w140.jpg?1582022611"
+    },
+    "fanship_count": 0,
+    "comment_count": 0,
+    "description": "<p>The best year for films since 2000. And well done, Mubi, for many fine screenings. Oh., and do see Apursansar’s list of 2019; as with all his yearly lists (and others) it invites international exploration</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/224497/image-w320.jpg?1582022611",
+      "https://assets.mubicdn.net/images/film/224259/image-w320.jpg?1607375540",
+      "https://assets.mubicdn.net/images/film/172930/image-w320.jpg?1580593225"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 158224,
+    "user_id": 56195,
+    "title": "21ST CENTURY",
+    "list_films_count": 49,
+    "updated_at": 1625913319,
+    "created_at": 1514445592,
+    "canonical_url": "https://mubi.com/lists/films-of-the-21st-century",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/158224/image-large.jpg?1599723762",
+      "medium": "https://assets.mubicdn.net/images/list/158224/image-medium.jpg?1599723762",
+      "small": "https://assets.mubicdn.net/images/list/158224/image-small.jpg?1599723762",
+      "square": "https://assets.mubicdn.net/images/list/158224/image-w140.jpg?1599723762"
+    },
+    "fanship_count": 48,
+    "comment_count": 0,
+    "description": "",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/22742/image-w320.jpg?1548073042",
+      "https://assets.mubicdn.net/images/film/1872/image-w320.jpg?1591624765",
+      "https://assets.mubicdn.net/images/film/1751/image-w320.jpg?1607463337"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 116,
+    "user_id": 56195,
+    "title": "ESSENTIAL FILMS BY WOMEN",
+    "list_films_count": 464,
+    "updated_at": 1625913000,
+    "created_at": 1257938751,
+    "canonical_url": "https://mubi.com/lists/essential-films-by-women",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/116/image-large.jpg?1611850399",
+      "medium": "https://assets.mubicdn.net/images/list/116/image-medium.jpg?1611850399",
+      "small": "https://assets.mubicdn.net/images/list/116/image-small.jpg?1611850399",
+      "square": "https://assets.mubicdn.net/images/list/116/image-w140.jpg?1611850399"
+    },
+    "fanship_count": 3596,
+    "comment_count": 2,
+    "description": "<p>Click on Read More and the links which appear. <strong>In tiers, a starter pack first, the rest in year order</strong>. Placings based on various polls, lists, selections, awards, ratings etc- especially Mubi (where Agnes Varda is Queen)- with leeway for hidden treasures and personal taste.</p>\nThe list was created in the early days of Mubi lists, before some more comprehensive ones on films by women came along: it’s intended as a manageable selection and a guide for where best to start. Comments, suggestions welcome.\n~ ~ ~\n<p>Not on Mubi: The Welshman (Walker).</p>\nOther lists:\n<p><a href=\"https://mubi.com/lists/mubi-poll-of-favourite-films-by-women-july-2011\" rel=\"nofollow\">Films by Women: Mubi Poll</a>, <br>\n<a href=\"https://mubi.com/lists/my-favourite-films-by-women\" rel=\"nofollow\">Films by Women: My Favourites</a>, <br>\n<a href=\"https://mubi.com/lists/female-iranian-directors\" rel=\"nofollow\">Female Iranian Directors</a> .</p>\nAlso, Apursansar’s lists:\n<p><a href=\"http://mubi.com/lists/apursansars-female-directors-canon\" rel=\"nofollow\">Apursansar’s Female Directors Canon</a>,<br>\n<a href=\"http://mubi.com/lists/japanese-female-directors\" rel=\"nofollow\">Japanese Female Directors</a> , <br>\n<a href=\"https://mubi.com/lists/latin-american-female-directors\" rel=\"nofollow\">Latin American Female Directors</a> .</p>\n~ ~ ~\n\n<p>*The HIStory of cinema is still to be re-written. Alice Guy-Blaché was one of the great pioneers of cinema, made hundreds of films, the first in 1896, before Méliès. Do check her out, there is skill and charm aplenty: I’ve done a list <a href=\"http://mubi.com/lists/alice-guy-blache-queen-of-the-pioneers\" rel=\"nofollow\">Alice Guy-Blaché, Queen of the Pioneers</a>. In 1910s Hollywood, in films like Suspense, Lois Weber matched Griffith for panache. Lotte Reiniger was a pioneering feature film animator in the 1920s, with her silhouettes in The Adventures of Prince Achmed,  while Germaine Dulac is widely credited with the first Surrealist film, The Seashell and the Clergyman (1928). Before Fantasia’s animated abstract Bach Fugue there was Mary Ellen Bute’s. Maya Deren was very influential on the post-war American avant-garde, though i must say her husband Alexander Hammid, who co-directed Meshes of the Afternoon, deserves more recognition too. Marie Menken is described by our great list-maker Grey Daisies as the unsung heroine of the avant-garde. Agnes Varda is the mother of the French New Wave, Chantal Akerman surely a major director, Jeanne Dielman one of the great minimalist films. The Bulgarian Binka Zheliazkova’s The Attached Balloon is just one of various neglected treasures by women. In notoriously patriarchal Iran, there have been several prominent female directors, putting Hollywood to shame. Often female co-directors get overlooked; Miéville with Godard, Ágnes Hranitzky with Bela Tarr, Evelyn Lambart with Norman McLaren, Katia Lund with Meirelles, Charlotte Zwerin with the Maysles….</p>\n<p>This site is honoured to have Chantal Akerman, Maria de Medeiros, Sally Potter, Julie Dash, Sadaf Foroughi, Allison Anders, Ava DuVernay among the users. Sally Potter has even done a list, My Teachers, as has Julie Dash. And good to have Agnes Varda’s liaison with the site and her films being championed so successfully. <a href=\"https://mubi.com/lists/the-essential-agnes-varda\" rel=\"nofollow\">The Essential Agnes Varda</a> .</p>\n<p>With uncertainty, I’m not including films by Lilly and Lana Wachowski who made their name when officially male, before their transgender assignments.</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/224497/image-w320.jpg?1582022611",
+      "https://assets.mubicdn.net/images/film/1565/image-w320.jpg?1572802645",
+      "https://assets.mubicdn.net/images/film/302/image-w320.jpg?1543381236"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 7288,
+    "user_id": 56195,
+    "title": "GREAT CINEMATOGRAPHERS",
+    "list_films_count": 302,
+    "updated_at": 1625911538,
+    "created_at": 1270937127,
+    "canonical_url": "https://mubi.com/lists/great-cinematographers",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/7288/image-large.png?1620208198",
+      "medium": "https://assets.mubicdn.net/images/list/7288/image-medium.png?1620208198",
+      "small": "https://assets.mubicdn.net/images/list/7288/image-small.png?1620208198",
+      "square": "https://assets.mubicdn.net/images/list/7288/image-w140.jpg?1620208198"
+    },
+    "fanship_count": 750,
+    "comment_count": 23,
+    "description": "<p>Suggestions very welcome.. Selected films of:</p>\n<p><strong>MIYAGAWA KAZUO</strong>:<br>\nRashomon,<br>\nMiss Oyu,<br>\nA Geisha,<br>\nUgetsu Monogatari,,<br>\nSansho the Bailiff,<br>\nChikamatsu Monogatari,<br>\nTales of the Taira Clan,<br>\nEnjo,<br>\nFloating Weeds,<br>\nYojimbo,<br>\nTokyo Olympiad,<br>\nIrezumi,<br>\nSilence,<br>\nKagemusha</p>\n<p><strong>VITTORIO STORARO</strong>:<br>\nBird of the Crystal Plumage,<br>\nThe Conformist,<br>\nThe Spider’s Stratagem,<br>\nLast Tango in Paris,<br>\n1900, <br>\nApocalypse Now,<br>\nReds,<br>\nThe Last Emperor,<br>\nThe Sheltering Sky,<br>\nDick Tracy,<br>\nBulworth.</p>\n<p><strong>ROBBY MULLER</strong>:<br>\nAlice in the Cities,<br>\nWrong Movement,<br>\nKings of the Road,<br>\nThe American Friend,<br>\nParis Texas,<br>\nRepo Man,<br>\nDown by Law,<br>\nDead Man,<br>\nBreaking the Waves,<br>\nGhost Dog,<br>\nDancer in the Dark.</p>\n<p><strong>SVEN NYKVIST</strong>:  <br>\nSawdust and Tinsel,<br>\nThrough a Glass Darkly,<br>\nWinter Light,<br>\nThe Silence,<br>\nPersona,<br>\nHour of the Wolf,<br>\nShame,<br>\nCries and Whispers,<br>\nThe Tenant,<br>\nFanny and Alexander,<br>\nThe Sacrifice,<br>\nThe Unbearable Lightness of Being,<br>\nCrimes and Misdemeanours.</p>\n<p><strong>GREGG TOLAND</strong>:<br>\nMad Love<br>\nHistory is Made at Night<br>\nWuthering Heights<br>\nThe Long Voyage Home<br>\nThe Grapes of Wrath<br>\nCitizen Kane<br>\nThe Little Foxes<br>\nBall of Fire<br>\nThe Best Years of our Lives</p>\n<p><strong>NESTOR ALMENDROS</strong>: <br>\nLa Collectioneuse<br>\nMy Night with Maud<br>\nClaire’s Knee<br>\nThe Wild Child<br>\nTwo English Girls<br>\nLa Gueule Ouverte<br>\nMes Petites Amoureuses<br>\nThe Story of Adele H<br>\nDays of Heaven<br>\nSophie’s Choice<br>\nConfidentially Yours</p>\n<p><strong>RAOUL COUTARD</strong>:<br>\nBreathless<br>\nChronicle of a Summer<br>\nLola<br>\nJules et Jim<br>\nVivre sa Vie<br>\nThe Dark Room of Damocles<br>\nContempt<br>\nAlphaville<br>\nPierrot le Fou<br>\n2 or 3 Things I Know about her<br>\nWeekend<br>\nZ<br>\nPassion<br>\nThe Birth of Love</p>\n<p><strong>SACHA VIERNY</strong>:<br>\nNight and Fog<br>\nLetter from Siberia<br>\nDiary of a Pregnant Woman<br>\nHiroshima mon Amour<br>\nLast Year at Marienbad<br>\nThe War is Over<br>\nBelle de Jour<br>\nHypothesis of a Stolen Painting<br>\nThree Crowns of the Sailor<br>\nA Zed and Two Noughts<br>\nThe Cook, the Thief his Wife and her Lover<br>\nProspero’s Books</p>\n<p><strong>GIANNI DI VENANZO</strong>:<br>\nIl Grido<br>\nBig Deal on Madonna Street<br>\nLa Notte<br>\nSalvatore Giuliano<br>\nEva<br>\nEclipse<br>\n8 1/2<br>\nJuliet of the Spirits</p>\n<p><strong>GORDON WILLIS</strong>:<br>\nKlute<br>\nThe Godfather<br>\nThe Godfather 2<br>\nThe Parallax View<br>\nAll the President’s Men<br>\nAnnie Hall<br>\nManhattan<br>\nZelig<br>\nBroadway Danny Rose<br>\nThe Purple Rose of Cairo</p>\n<p><strong>CHRISTOPHER DOYLE</strong>:<br>\nThat Day, on the Beach<br>\nDays of Being Wild<br>\nChungking Express<br>\nAshes of Time<br>\nFallen Angels<br>\nHappy Together<br>\nIn the Mood for Love<br>\nThe Quiet American<br>\nRabbit Proof Fence<br>\nHero<br>\nLast Life in the Universe<br>\n2046</p>\n<p><strong>ROGER DEAKINS</strong>:<br>\n1984<br>\nSid and Nancy<br>\nBarton Fink<br>\nPassion Fish<br>\nThe Shawshank Redemption<br>\nDead Man Walking<br>\nFargo<br>\nThe Big Lebowski<br>\nThe Man who Wasn’t There<br>\nA Beautiful Mind<br>\nNo Country for Old Men<br>\nThe Assassination of Jesse James by the Coward Robert Ford<br>\nRevolutionary Road<br>\nThe Reader<br>\nTrue Grit<br>\nSicario<br>\nBlade Runner: 2049</p>\n<p><strong>EDUARD TISSE</strong>:<br>\nStrike<br>\nBattleship Potemkin<br>\nOctober<br>\nAlexander Nevsky<br>\nIvan the Terrible <br>\nIvan the Terrible 2</p>\n<p><strong>GIORGOS ARVANITIS</strong>:<br>\nReconstruction<br>\nThe Travelling Players<br>\nAlexander the Great<br>\nVoyage to Cythera<br>\nLandscape in the Mist<br>\nSuspended Step of the Stork<br>\nUlysses’ Gaze<br>\nMother of the Dunes<br>\nEternity and a Day<br>\nThe Last Letter</p>\n<p><strong>CONRAD HALL</strong>:<br>\nIn Cold Blood<br>\nCool Hand Luke<br>\nButch Cassidy and the Sundance Kid<br>\nFat City<br>\nMarathon Man<br>\nAmerican Beauty<br>\nRoad to Perdition</p>\n<p><strong>LEE GARMES</strong>:<br>\nMorocco<br>\nDishonoured<br>\nShanghai Express<br>\nScarface<br>\nDuel in the Sun<br>\nNightmare Alley<br>\nCaught<br>\nDetective Story<br>\nThe Lusty Men<br>\nThe Desperate Hours</p>\n<p><strong>SUBRATA MITRA</strong>:<br>\nPather Panchali<br>\nAparajito<br>\nThe World of Apu<br>\nDevi<br>\nMahanagar</p>\n<p><strong>ROBERT BURKS</strong>:<br>\nStrangers on a Train<br>\nRear Window<br>\nVertigo<br>\nNorth by Northwest<br>\nThe Birds <br>\nMarnie</p>\n<p><strong>STANLEY CORTEZ</strong>:<br>\nThe Magnificent Ambersons<br>\nSince you Went Away<br>\nSecret Beyond the Door<br>\nNight of the Hunter<br>\nThe Three Faces of Eve<br>\nShock Corridor<br>\nThe Naked Kiss</p>\n<p><strong>CHRIS MENGES</strong>:<br>\nKes<br>\nBlack Jack<br>\nMade in Britain<br>\nLocal Hero<br>\nThe Killing Fields<br>\nThe Mission<br>\nThe Three Burials of Melquiades Estrada<br>\nThe Reader</p>\n<p><strong>MICHAEL BALLHAUS</strong>:<br>\nFox and his Friends<br>\nChinese Roulette<br>\nThe Marriage of Maria Braun<br>\nGoodfellas<br>\nBram Stoker’s Dracula<br>\nThe Age of Innocence<br>\nQuiz Show<br>\nThe Departed</p>\n<p><strong>BORIS KAUFMAN</strong>:<br>\nA Propos de Nice<br>\nZéro de Conduite<br>\nL’Atalante<br>\nOn the Waterfront<br>\nBaby Doll<br>\n12 Angry Men<br>\nSplendour in the Grass<br>\nLong Day’s Journey into Night<br>\nThe Pawnbroker</p>\n<p><strong>JACK CARDIFF</strong>:<br>\nThe Life and Death of Colonel Blimp<br>\nA Matter of Life and Death<br>\nBlack Narcissus<br>\nThe Red Shoes<br>\nPandora and the Flying Dutchman<br>\nThe African Queen<br>\nThe Barefoot Contessa</p>\n<p><strong>AGNES GODARD</strong>:<br>\nJacquot de Nantes<br>\nDream Life of Angels<br>\nBeau Travail<br>\nTrouble Every Day<br>\nFriday Night<br>\nThe Intruder<br>\nGolden Door<br>\n35 Shots of Rum</p>\n<p><strong>WILLIAM LUBTCHANSKY</strong>:<br>\nLe Pont du Nord<br>\nClass Relations<br>\nShoah<br>\nLa Belle Noiseuse<br>\nJeanne la Pucelle: The Battles<br>\nJeanne la Pucelle: The Prisons<br>\nSecret Défense<br>\nFarewell, Home Sweet Home<br>\nMonday Morning<br>\nThe Story of Marie and Julien<br>\nA Visit to the Louvre<br>\nRegular Lovers<br>\nGardens in Autumn<br>\nThe Duchess of Langeais</p>\n<p><strong>GABRIEL FIGUEROA</strong>:<br>\nMaria Candelaria<br>\nThe Pearl<br>\nSalon Mexico<br>\nLos Olvidados<br>\nEl<br>\nNazarin<br>\nMacario<br>\nThe Young One<br>\nExterminating Angel<br>\nAutumn Days</p>\n<p><strong>JAMES WONG HOWE</strong>:<br>\nShanghai Express<br>\nThe Prisoner of Zenda<br>\nFantasia<br>\nKings Row<br>\nBody and Soul<br>\nPicnic<br>\nSweet Smell of Success<br>\nHud<br>\nSeconds</p>\n<p><strong>GEORGI RERBERG</strong>:<br>\nAsya’s Happiness<br>\nUncle Vanya<br>\nMirror<br>\nStalker<br>\nWaati</p>\n<p><strong>CHARLES ROSHER</strong>:<br>\nSunrise<br>\nThe Yearling<br>\nShow Boat</p>\n<p><strong>SERGEI URUSEVSKY</strong>:<br>\nThe Cranes are Flying<br>\nThe Letter Never Sent<br>\nI am Cuba</p>\n<p><strong>PIN BIN LEE</strong>:<br>\nThe Time to Live and the Time to Die<br>\nDust in the Wind<br>\nPuppetmaster<br>\nFlowers of Shanghai<br>\nVertical Ray of the Sun<br>\nIn the Mood for Love<br>\nMillennium Mambo<br>\nSpringtime in a Small Town<br>\nCafé Lumiere<br>\nThree Times<br>\nFlight of the Red Balloon<br>\nNorwegian Wood<br>\nThe Assassin</p>\n<p><strong>EMMANUEL LUBEZKI</strong>:<br>\nLike Water for Chocolate<br>\n A Little Princess<br>\n Y Tu Mama Tambien<br>\n The New World<br>\n Children of Men<br>\n Tree of Life<br>\n Gravity<br>\n Birdman<br>\nThe Revenant</p>\n<p><strong>DARIUS KHONDJI</strong>:<br>\nDelicatessen<br>\nCity of Lost Children<br>\nSe7En<br>\nMidnight in Paris<br>\nAmour<br>\nCastello Cavalcanti<br>\nOkja</p>\n<p>hard to know when to stop! And not forgetting <strong>Ghislain Cloquet, Haskell Wexler, G.W.“Billy” Bitzer, Miki Minoru, John Alton, Robert Krasker, Janusz Kominski, Slavomir Idziak, Thomas Mauch, Henri Alekan, Freddie Francis, Gunnar Fischer, Henning Bendtsen, Robert Richardson, Luís Cuadrado, Acácio de Almeida, Henri Decae, Ricardo Aronovich, John Alcott, Frederick Elmes, Miyajima Yoshio, Vadim Yusov, Vilmos Zsigmond, Russell Metty</strong>…</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/307/image-w320.jpg?1543575612",
+      "https://assets.mubicdn.net/images/film/1561/image-w320.jpg?1582303008",
+      "https://assets.mubicdn.net/images/film/20191/image-w320.jpg?1587724379"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 111,
+    "user_id": 56195,
+    "title": "ESSENTIAL DOCUMENTARIES",
+    "list_films_count": 272,
+    "updated_at": 1625908459,
+    "created_at": 1257936283,
+    "canonical_url": "https://mubi.com/lists/101-favourite-documentaries",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/film/574/image-w1280.jpg?1546826446",
+      "medium": "https://assets.mubicdn.net/images/film/574/image-w384.jpg?1546826446",
+      "small": "https://assets.mubicdn.net/images/film/574/image-w128.jpg?1546826446",
+      "square": "https://assets.mubicdn.net/images/film/574/image-w140.jpg?1546826446"
+    },
+    "fanship_count": 1089,
+    "comment_count": 0,
+    "description": "<p>2 TIERS, IN YEAR ORDER. I’m including some films which blur the line between reality and fiction (People on Sunday, The War Game, My Winnipeg, F for Fake), drama (Close Up, Our Hitler) or avant-garde (Sleep Has Her House. As I Was Moving Ahead..). Triumph of the Will? Monstrous, included as a warning and useful for a double bill with Night and Fog</p>\n<p>~</p>\n<p>Not on Mubi: The Welshman (Walker), Buried by Mainstream Media: The True Story of Madeleine McCann (Hall)</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/574/image-w320.jpg?1546826446",
+      "https://assets.mubicdn.net/images/film/296/image-w320.jpg?1563962189",
+      "https://assets.mubicdn.net/images/film/238/image-w320.jpg?1577434731"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 119,
+    "user_id": 56195,
+    "title": "ESSENTIAL ANIMATION",
+    "list_films_count": 313,
+    "updated_at": 1625907299,
+    "created_at": 1257939952,
+    "canonical_url": "https://mubi.com/lists/favourite-animations",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/119/image-large.jpg?1613630339",
+      "medium": "https://assets.mubicdn.net/images/list/119/image-medium.jpg?1613630339",
+      "small": "https://assets.mubicdn.net/images/list/119/image-small.jpg?1613630339",
+      "square": "https://assets.mubicdn.net/images/list/119/image-w140.jpg?1613630339"
+    },
+    "fanship_count": 1030,
+    "comment_count": 15,
+    "description": "<p>Click on Read More and the links which appear. A list in 3 tiers, most essential first, the rest in year order. Missing from this site: Window (Kuri)</p>\n<p><sub>~</sub></p>\n<p>NOTABLE ANIMATORS</p>\n<p><a href=\"http://en.wikipedia.org/wiki/Alexandre_Alexeieff\" rel=\"nofollow\">Alexandre Alexeieff</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Hideaki_Anno\" rel=\"nofollow\">Anno Hideaki</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Tex_Avery\" rel=\"nofollow\">Tex Avery</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Fr%C3%A9d%C3%A9ric_Back\" rel=\"nofollow\">Frédéric Back</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Ralph_Bakshi\" rel=\"nofollow\">Ralph Bakshi</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Joseph_Barbera\" rel=\"nofollow\">Joseph Barbera</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Brad_Bird\" rel=\"nofollow\">Brad Bird</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Walerian_Borowczyk\" rel=\"nofollow\">Walerian Borowczyk</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Ivo_Caprino\" rel=\"nofollow\">Ivo Caprino</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Sylvain_Chomet\" rel=\"nofollow\">Sylvain Chomet</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Walt_Disney\" rel=\"nofollow\">Walt Disney</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Pete_Docter\" rel=\"nofollow\">Pete Docter</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Piotr_Dumala\" rel=\"nofollow\">Piotr Dumala</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Oskar_Fischinger\" rel=\"nofollow\">Oskar Fischinger</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Dave_Fleischer\" rel=\"nofollow\">Dave Fleischer</a>, <br>\n<a href=\"http://en.wikipedia.org/wiki/Friz_Freleng\" rel=\"nofollow\">Friz Freleng</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/William_Hanna\" rel=\"nofollow\">William Hanna</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Don_Hertzfeldt\" rel=\"nofollow\">Don Hertzfeldt</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Chuck_Jones\" rel=\"nofollow\">Chuck Jones</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Larry_Jordan\" rel=\"nofollow\">Larry Jordan</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/William_Kentridge\" rel=\"nofollow\">William Kentridge</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Fyodor_Khitruk\" rel=\"nofollow\">Fyodor Khitruk</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Satoshi_Kon\" rel=\"nofollow\">Kon Satoshi</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Yoji_Kuri\" rel=\"nofollow\">Kuri Yoji</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Ren%C3%A9_Laloux\" rel=\"nofollow\">René Laloux</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/John_Lasseter\" rel=\"nofollow\">John Lasseter</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Caroline_Leaf\" rel=\"nofollow\">Caroline Leaf</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Jan_Lenica\" rel=\"nofollow\">Jan Lenica</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Len_Lye\" rel=\"nofollow\">Len Lye</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Ivan_Maximov\" rel=\"nofollow\">Ivan Maximov</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Winsor_McCay\" rel=\"nofollow\">Winsor McCay</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Norman_McLaren\" rel=\"nofollow\">Norman McLaren</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Hayao_Miyazaki\" rel=\"nofollow\">Miyazaki Hayao</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Yuriy_Norshteyn\" rel=\"nofollow\">Yuri Norstein</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Mamoru_Oshii\" rel=\"nofollow\">Oshii Mamoru</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Nick_Park\" rel=\"nofollow\">Nick Park</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Brothers_Quay\" rel=\"nofollow\">Stephen and Timothy Quay</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Lotte_Reiniger\" rel=\"nofollow\">Lotte Reiniger</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Georges_Schwizgebel\" rel=\"nofollow\">Georges Schwizgebel</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Henry_Selick\" rel=\"nofollow\">Henry Selick</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Ben_Sharpsteen\" rel=\"nofollow\">Ben Sharpsteen</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Makoto_Shinkai\" rel=\"nofollow\">Shinkai Makoto</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Andrew_Stanton\" rel=\"nofollow\">Andrew Stanton</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Ladislas_Starevich\" rel=\"nofollow\">Wladyslaw Starewicz</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Jan_Svankmajer\" rel=\"nofollow\">Jan Svankmajer</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Isao_Takahata\" rel=\"nofollow\">Takahata Isao</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Te_Wei\" rel=\"nofollow\">Te Wei</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Jiri_Trnka\" rel=\"nofollow\">Jiri Trnka</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Lee_Unkrich\" rel=\"nofollow\">Lee Unkrich</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Koji_Yamamura\" rel=\"nofollow\">Yamamura Koji</a>,<br>\n<a href=\"https://en.wikipedia.org/wiki/Masaaki_Yuasa\" rel=\"nofollow\">Yuasa Masaaki</a>,<br>\n<a href=\"http://en.wikipedia.org/wiki/Karel_Zeman\" rel=\"nofollow\">Karel Zeman</a>,</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/2571/image-w320.jpg?1481124404",
+      "https://assets.mubicdn.net/images/film/979/image-w320.jpg?1615460383",
+      "https://assets.mubicdn.net/images/film/21500/image-w320.jpg?1517766735"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 769,
+    "user_id": 56195,
+    "title": "BIOGRAPHIES",
+    "list_films_count": 270,
+    "updated_at": 1625907267,
+    "created_at": 1258576752,
+    "canonical_url": "https://mubi.com/lists/film-biographies",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/769/image-large.jpg?1615184739",
+      "medium": "https://assets.mubicdn.net/images/list/769/image-medium.jpg?1615184739",
+      "small": "https://assets.mubicdn.net/images/list/769/image-small.jpg?1615184739",
+      "square": "https://assets.mubicdn.net/images/list/769/image-w140.jpg?1615184739"
+    },
+    "fanship_count": 70,
+    "comment_count": 12,
+    "description": "<p>Individuals are collectives, collectives individuals. Some individual collectives I admire.:</p>\n<p>Muhammad Ali,<br>\nDave Allen,<br>\nB R Ambedkar, <br>\nFred Astaire,<br>\nDavid Attenborough,<br>\nJames Baldwin,<br>\nBasho,<br>\nLudwig van Beethoven<br>\nAneurin Bevan,<br>\nJames Dean Bradfield, <br>\nSiddhartha Buddha,<br>\nVashti Bunyan,<br>\nRachel Carson,<br>\nCheng Yen,<br>\nMarie Sklodowska Curie,<br>\nDafydd ap Gwilym,<br>\nMiles Davis,<br>\nAndrée De Jongh,<br>\nCatherine Destivelle,<br>\nDenis Diderot,<br>\nFrederick Douglass,<br>\nAndrée Dumon,<br>\nGareth Edwards (rugby player),<br>\nRoger Federer,<br>\nHiroshige Ando,<br>\nHokusai Katsushika,<br>\nVictor Jara,<br>\nGwen John,<br>\nKagawa Kyoko, <br>\nJohn Keats,<br>\nHelen Keller,<br>\nMajid Khan (cricketer),<br>\nMartin Luther King,<br>\nJanusz Korczak,<br>\nSatish Kumar,<br>\nLeonardo Da Vinci,<br>\nLi Bai/Li Po,<br>\nFederico Garcia Lorca,<br>\nCaroline Lucas,<br>\nPatrice Lumumba,<br>\nWangari Maathai,<br>\nGraça Machel, <br>\nNelson Mandela,<br>\nAaron Maté,<br>\nChico Mendes,<br>\nCharles Mingus,<br>\nMiyazawa Kenji,<br>\nMizoguchi Kenji,<br>\nClaude Monet,<br>\nMarilyn Monroe,<br>\nJackie Morris,<br>\nRosa Mota,<br>\nMohammad Mossadegh,<br>\nMurakami Haruki,<br>\nThomas Paine,<br>\nMichael Palin,<br>\nSylvia Pankhurst,<br>\nJyotirao Phule,<br>\nSavitribai Phule <br>\nJohn Pilger,<br>\nLucia Popp,<br>\nGiacomo Puccini,<br>\nSatyajit Ray,<br>\nRembrandt van Rijn,<br>\nJean Renoir,<br>\nViv Richards,<br>\nRainer Maria Rilke,<br>\nYongey Mingyur Rinpoche,<br>\nHans Scholl,<br>\nSophie Scholl,<br>\nWilliam Shakespeare,<br>\nJean Sibelius,<br>\nLeonor Silveira,<br>\nSitting Bull,<br>\nBruce Springsteen,<br>\nJill Stein,<br>\nSuzuki Shunryu,<br>\nRabindranath Tagore,<br>\nTakamine Hideko,<br>\nThich Nhat Hanh,<br>\nEdward Thomas,<br>\nTitian,<br>\nHarriet Tubman,<br>\nAlan Turing,<br>\nJ.M.W Turner,<br>\nDesmond Tutu,<br>\nVincent Van Gogh,,<br>\nRalph Vaughan Williams,<br>\nGiuseppe Verdi,<br>\nJohannes Vermeer,<br>\nAlfred Russel Wallace,<br>\nGerrard Winstanley.<br>\nStefan Zweig</p>\n<p>I love the films of Mizoguchi and the music of Charles Mingus more than I admire their abrasive personalities, while i’m not too keen on the politics of Sibelius and Fred Astaire.</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/2386/image-w320.jpg?1470060806",
+      "https://assets.mubicdn.net/images/film/301/image-w320.jpg?1581348517",
+      "https://assets.mubicdn.net/images/film/341/image-w320.jpg?1510677281"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 7564,
+    "user_id": 56195,
+    "title": "SUSAN SONTAG'S FAVOURITE FILMS",
+    "list_films_count": 95,
+    "updated_at": 1625907103,
+    "created_at": 1271409527,
+    "canonical_url": "https://mubi.com/lists/susan-sontags-favourite-films",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/7564/image-large.jpg?1552241147",
+      "medium": "https://assets.mubicdn.net/images/list/7564/image-medium.jpg?1552241147",
+      "small": "https://assets.mubicdn.net/images/list/7564/image-small.jpg?1552241147",
+      "square": "https://assets.mubicdn.net/images/list/7564/image-w140.jpg?1552241147"
+    },
+    "fanship_count": 1138,
+    "comment_count": 30,
+    "description": "<p>Susan Sontag, the distinguished and well-known U.S writer, cultural commentator, film-maker…</p>\n<p>From different top 10s over the years, including for Sight &amp; Sound, John Kobal’s poll in the last 80s, a Russian poll in 1995 (thanks to Angel for that), also a selection of 50 in the 70s, a late selection of 30 (thanks to José Sarmiento), also some selections for a Japanese season. Any others please.</p>\n<p>She came to rate Mizoguchi very highly- more highly than Kurosawa who is better represented here. Anyone know which other films by him should be listed here?</p>\n<p>Read more <a href=\"http://www.newyorker.com/online/blogs/movies/2012/05/susan-sontag-best-films-list.html#ixzz1x1vfQkLl\" rel=\"nofollow\">here</a></p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/296/image-w320.jpg?1563962189",
+      "https://assets.mubicdn.net/images/film/295/image-w320.jpg?1550037622",
+      "https://assets.mubicdn.net/images/film/284/image-w320.jpg?1562857368"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 1152,
+    "user_id": 56195,
+    "title": "PORTUGAL, PAIS MARAVILHOSO, LAND OF MY DREAMS",
+    "list_films_count": 84,
+    "updated_at": 1625903671,
+    "created_at": 1259400625,
+    "canonical_url": "https://mubi.com/lists/portugal-land-of-my-dreams",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/1152/image-large.jpg?1489131202",
+      "medium": "https://assets.mubicdn.net/images/list/1152/image-medium.jpg?1489131202",
+      "small": "https://assets.mubicdn.net/images/list/1152/image-small.jpg?1489131202",
+      "square": "https://assets.mubicdn.net/images/list/1152/image-w140.jpg?1489131202"
+    },
+    "fanship_count": 445,
+    "comment_count": 43,
+    "description": "<p>The image above is of beloved Caminha in North Portugal, looking across the Minho estuary from Galicia, Spain.</p>\n<p>Click on Read More and then the links which appear.</p>\n<p><a href=\"http://aimore.org/flag/Portugal.jpg\" rel=\"nofollow\">here</a> for starters.</p>\n<p>Portugal, pais lindo e maravilhoso. Blessed land of warmth and beauty, in its people as well as climate and landscape! Land of discoverers and worthy of discovery. When in Portugal, like the poet Pessoa, tenho em mim todos os sonhos do mundo/ i have in me all the dreams of the world.</p>\n<p>The great director <a href=\"http://image.guardian.co.uk/sys-images/Arts/Arts_/Pictures/2008/03/27/oliveira460.jpg\" rel=\"nofollow\">Manoel de Oliveira</a>, a colossus of Portuguese cinema, was still prolific up to his death aged 106, well into his 10th different decade of film-making! R.I.P.</p>\n<p>Manoel de Oliveira was born in Porto, Portugal on December 11, 1908, to Francisco José de Oliveira and Cândida Ferreira Pinto. His family were wealthy industrialists and agricultural landowners. He attended school in Galicia, Spain and his goal, as a teenager, was to become an actor. He enrolled in Italian film-maker Rino Lupo’s acting school at age 20, but later changed his mind when he saw Walther Ruttmann’s documentary Berlin: Symphony of a City. This prompted him to direct his first film, also a documentary, titled Douro, Faina Fluvial (1931). He also has the distinction of having acted in the second Portuguese sound film, A Canção de Lisboa (1933).</p>\n<p>His first feature film came much later, in 1942. Aniki-Bóbó, a portrait of Oporto’s street children, was a commercial failure when it opened, and its merit only came to be recognised over time. This drawback forced Manoel de Oliveira to abandon other film projects he was involved in, and to dedicate himself to running his family vineyard. He re-emerged onto the film scene in 1956 with The Artist and the City, a work that marked a turning point in Oliveira’s conception of the cinema.</p>\n<p>In 1963, O Acto de Primavera (The Rite of Spring), a documentary depicting an annual passion play, marked a turning point for his career. This was shortly followed by A caça (The Hunt), a grim feature film that contrasted with the happy tones of his previous documentary. Despite the widespread acclaim garnered by both films, he would not return to the director’s seat until the 1970s. Since 1990 (when he turned 82), he has made at least one film each year. His film, Christopher Columbus – the Enigma (2007), was shot partly in New York.</p>\n<p>Manoel de Oliveira has said that he directs movies for the sheer pleasure of it, regardless of critical reaction. He maintains a quiet life away from the spotlights.</p>\n<p>In 2008, Oliveira was awarded a doctorate degree honoris causa by the University of the Algarve. He has also been awarded the Order of St. James of the Sword by the President of Portugal. In addition, he has received multiple honours such as those of the Cannes, Venice and Montréal film festivals. He has been awarded two Career Golden Lions, in 1985 and 2004, and a Golden Palm for his lifetime achievements in 2008.</p>\n<p>Manoel de Oliveira married Maria Isabel Brandão de Meneses de Almeida Carvalhais in Porto on December 4, 1940. They have two children: Manuel Casimiro Brandão Carvalhais de Oliveira (born 1941) and Adelaide Maria Brandão Carvalhais de Oliveira (born 1948). He has several grandchildren through his daughter Adelaide.</p>\n<p>He was not only a film director. He also competed as a race car driver in his younger days. In the 1937 Grand Prix season he competed in and won the International Estoril Circuit race, driving a Ford V8 Special.</p>\n<p>Manoel de Oliveira was chosen to give the welcoming speech at Pope Benedict XVI’s meeting with representatives of the Portuguese cultural world on 12 May 2010 at the Belém Cultural Center. In the speech, titled “Religion and Art”, he said that morality and art may well have derived from the religious attempt at “a explanation of the existence of human beings” with regard to their “concrete insertion in the Cosmos”. The arts “have always been strictly linked to religions” and Christianity has been “prodigal in artistic expressions”. In an interview published the day before, Oliveira, who was raised a Catholic, said that, “doubts or not, the religious aspect of life has always accompanied me,” and added, “All my films are religious.”<br>\n(wikipedia)</p>\n<p><sub>~</sub></p>\n<p>Another top director, <a href=\"http://imagens4.publico.pt/imagens.aspx/810654?tp=UH&amp;amp;db=IMAGENS&amp;amp;w=749\" rel=\"nofollow\">João César Monteiro</a> .</p>\n<p>João César Monteiro (1939-2003) was born in Figueira da Foz, a cosmopolitan beach resort in Portugal and moved to Lisbon at the age of 15 where he continued his studies.</p>\n<p>João César Monteiro remains among the most indelible and unusual figures in the history of Portuguese cinema, a visionary and profoundly eccentric filmmaker whose unique contribution to postwar European film is only gradually being recognized today. A cosmopolite imagination tethered by a provincial attachment to Lisbon, a libertine with an obscurely puritanical streak, an unrelenting aesthete guided by an archaic spirit – Monteiro was a deliberately contradictory and difficult artist who obdurately resisted affiliation with any declared “school” of filmmaking. Monteiro dedicated himself instead to a mode of sublimely, and often perversely, high modernism fascinated by a rich undercurrent between the cinema and the other arts – especially poetry, painting, theater, literature and music. Like the films of his compatriot Manoel de Oliveira (b. 1908), Monteiro’s cinema was also animated by an alternately cryptic and trenchant political agenda that took frequent target at the holy trinity of Church, State and Family still firmly entrenched after the fall of the Salazar dictatorship. In such seminal early works as Paths and Silvestre, Monteiro treated obscure Portuguese myths and legends as Rosetta stones for understanding the darkest shadows of the national unconscious and suggesting the ways in which the country’s imperialist and patriarchal legacies continue to shape its citizens. In opulent late works like God’s Comedy and Come and Go, Monteiro channeled his lasting preoccupation with corporality and perverse sexuality into a sustained interrogation of individual agency and collective desire.</p>\n<p>Raised in a devoutly Catholic family yet an avowed atheist as an adult, in many of his late films Monteiro cast himself in the recurrent leading role of “Joao do Deus”- named after the Portuguese-born patron saint of prostitutes, the infirm and fishermen but a wholly secular figure, a perverse Buster Keaton-like dreamer drawn to young women and possessed of a patient defiance of the established social order. A curious religious logic also guided the development of Monteiro’s extraordinary visual style, which moved from the radical mise-en-scene of the early work towards an increasing austerity shaped, above all, by Monteiro’s proclaimed distrust of artificial light – which reached its apotheosis in Snow White – and his desire to capture the effulgent mystery of sunlight and its shadows.</p>\n<p>His work, polemic and hard to classify, has a lyric quality that some identify as “film-poem”, however his work is often satirical and cynical. He plays the principal character in many of his films. His work has been the subject of study by Portuguese and international critics and <br>\nacademicians, and he is recognized, along with Manoel de Oliveira, as a giant of Portuguese cinema<br>\n(Harvard Film Archive)</p>\n<p>Monteiro won Mubi’s 2nd Directors Cup!</p>\n<p><sub>~</sub></p>\n<p>This list is in year order (or will be fully when a glitch is sorted), including some set in Portugal by non-Portuguese directors too. .</p>\n<p>My favourites: <strong>Abraham Valley</strong>, <strong>Mysteries of Lisbon</strong> <strong>Aniki Bobo</strong>, <strong>Silvestre</strong>, <strong>Tabu</strong>.</p>\n<p>Hats off to the extraordinary prolific late Chilean director Raul Ruiz, who though mainly based in France seems to have made Portugal something of a cinematic second or third home.  As i am not (yet) Portuguese- at least officially if not in spirit- i have barely scratched the surface of the country’s full cinematic and cultural riches.</p>\n<p>This list is now a selective not comprehensive one, since the many films originally listed were deleted by a mubi glitch.</p>\n<p><sub>~</sub></p>\n<p>Wikipedia <a href=\"http://en.wikipedia.org/wiki/Cinema_of_Portugal\" rel=\"nofollow\">CINEMA OF PORTUGAL</a></p>\n<p>i see that Dinis Guarda, co-author with Nuno Figueiredo of <strong>Portugal: Um Retrato Cinematográfico/ Portugal: A Cinematographic Portrait</strong> is on Mubi.</p>\n<p><strong>Other lists</strong><br>\nSee also Kuxa Kanema (aka Cyclo X)‘s list on <a href=\"http://mubi.com/lists/15099\" rel=\"nofollow\">Monteiro</a>, and Shakti’s list “O Fado” about that great form of music, the soul of Portugal. Monteiro is one of 3 directors covered in my list <a href=\"http://mubi.com/lists/11489\" rel=\"nofollow\">Groundhog Day Directors</a> as he was born Feb 2. I’ve also done a list on <a href=\"http://mubi.com/lists/13084\" rel=\"nofollow\">Leonor Silveira</a>, and <a href=\"http://mubi.com/lists/paintings-of-spain-and-portugal\" rel=\"nofollow\">Paintings of Spain and Portugal</a></p>\n<p>Actress <a href=\"http://upload.wikimedia.org/wikipedia/commons/9/93/Maria_de_Medeiros_Cannes.jpg\" rel=\"nofollow\">Maria de Medeiros</a> , who directed Captains of April, about the 1974 Carnation Revolution.</p>\n<p><sub>~</sub>~~~~~~</p>\n<p><strong>BEYOND FILMS</strong></p>\n<p>I cannot resist more pictures of this celestial country.</p>\n<p><a href=\"http://www.planetware.com/photos-large/P/peneda-geres-national-park.jpg#parque%20nacional%20ger%EAs%20630x440\" rel=\"nofollow\">Peneda-Geres national park</a> – with the lakes and mountains, a heavenly spot.</p>\n<p><a href=\"http://traveltoeat.com/wp-content/uploads/2013/01/wpid-Photo-Jan-28-2013-711-AM.jpg\" rel=\"nofollow\">Pena palace, Sintra</a></p>\n<p><sub>~</sub>~</p>\n<p>Then there’s the immortal national treasure, fado singer <a href=\"https://www.youtube.com/watch?v=1YriVM8sC7M\" rel=\"nofollow\">Amalia Rodrigues</a> , here singing O Fado Portugues.</p>\n<p>Ah, Amalia! Ela acaricia como a seda, banha como o luar e penetra como o relâmpago. She caresses like silk, bathes like moonlight and pierces like lightning.</p>\n<p>and</p>\n<p>Fernando Pessoa – MAR PORTUGUÊS</p>\n<p>Ó mar salgado, quanto do teu sal<br>\nSão lágrimas de Portugal!<br>\nPor te cruzarmos, quantas mães choraram,<br>\nQuantos filhos em vão rezaram!</p>\n<p>Quantas noivas ficaram por casar<br>\nPara que fosses nosso, ó mar!<br>\nValeu a pena? Tudo vale a pena<br>\nSe a alma não é pequena.</p>\n<p>Quem quere passar além do Bojador<br>\nTem que passar além da dor.<br>\nDeus ao mar o perigo e o abismo deu,<br>\nMas nele é que espelhou o céu.</p>\n<p>Oh salty sea, how much of your salt<br>\nAre tears of Portugal!<br>\nSo we might cross you, how many mothers cried,<br>\nHow many sons prayed in vain!</p>\n<p>How many brides were never to marry<br>\nfor you to be ours, oh sea!<br>\nWas it worth it?  Everything is worthwhile<br>\nIf the soul is not small.</p>\n<p>Whoever wants to venture beyond Bojador<br>\nMust venture beyond suffering.<br>\nGod gave the sea danger and deep abyss,<br>\nBut on it He also mirrored the sky.</p>\n<p>(my translation attempt)</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/47029/image-w320.jpg?1616792421",
+      "https://assets.mubicdn.net/images/film/114810/image-w320.jpg?1569661788",
+      "https://assets.mubicdn.net/images/film/106038/image-w320.jpg?1445936765"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 5232,
+    "user_id": 56195,
+    "title": "ON THE ROAD",
+    "list_films_count": 237,
+    "updated_at": 1625903275,
+    "created_at": 1267349897,
+    "canonical_url": "https://mubi.com/lists/on-the-road",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/5232/image-large.jpg?1486735820",
+      "medium": "https://assets.mubicdn.net/images/list/5232/image-medium.jpg?1486735820",
+      "small": "https://assets.mubicdn.net/images/list/5232/image-small.jpg?1486735820",
+      "square": "https://assets.mubicdn.net/images/list/5232/image-w140.jpg?1486735820"
+    },
+    "fanship_count": 865,
+    "comment_count": 23,
+    "description": "",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/995/image-w320.jpg?1551324707",
+      "https://assets.mubicdn.net/images/film/150844/image-w320.jpg?1470189070",
+      "https://assets.mubicdn.net/images/film/1502/image-w320.jpg?1580726159"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6354,
+    "user_id": 56195,
+    "title": "PAINTERS AND FILMS",
+    "list_films_count": 332,
+    "updated_at": 1625901894,
+    "created_at": 1269367620,
+    "canonical_url": "https://mubi.com/lists/painters-and-films",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/6354/image-large.jpg?1600443903",
+      "medium": "https://assets.mubicdn.net/images/list/6354/image-medium.jpg?1600443903",
+      "small": "https://assets.mubicdn.net/images/list/6354/image-small.jpg?1600443903",
+      "square": "https://assets.mubicdn.net/images/list/6354/image-w140.jpg?1600443903"
+    },
+    "fanship_count": 1324,
+    "comment_count": 52,
+    "description": "<p>Click on Read More and the links which then appear.</p>\n<p><a href=\"http://www.newyorker.com/wp-content/uploads/2015/06/150629-dvd-utamaro.jpg\" title=\"Mizoguchi\" rel=\"nofollow\">Five Women around Utamaro</a> .</p>\n<p>Films about, or which show the influence of, painters. This list is a mix of drama biographies, documentaries and also.some fictions.</p>\n<p>Not on this site:</p>\n<p>What She Wants,<br>\nSuperartist,</p>\n<p>~~</p>\n<p>Kurosawa’s Dreams has a section with Van Gogh.<br>\nCaravaggio’s chiaroscuro lighting appears cinematic, especially suited to film noir.<br>\nTarkovsky’s <a href=\"http://people.ucalgary.ca/~tstronds/nostalghia.com/TheTopics/overscan/mirror_std.jpg\" rel=\"nofollow\">Mirror</a> has Brueghelesque images (Hunters in the Snow..), and Da Vinci paintings like Ginevra de Benci feature strongly.</p>\n<p>Rembrandt’s <a href=\"http://www.rembrandtpainting.net/prodigal_son/Rembrandt.jpg\" rel=\"nofollow\">Return of the Prodigal Son</a> is imitated in Tarkovsky’s <a href=\"http://christoumazoucmp.files.wordpress.com/2009/11/solaris_72-prodigalmovie.gif?w=460\" rel=\"nofollow\">Solaris</a> .</p>\n<p>Sokurov wanted Mother and Son to reflect the style of Friedrich.<br>\nBrueghel’s Procession to Calvary is brought to life in the Polish-Swedish film The Mill and the Cross.<br>\nVermeer paintings have influenced films like Spirit of the Beehive and A Zed and Two Noughts.<br>\nGreenaway’s admiration for Rembrandt and Dutch art generally as well as Vermeer has been apparent in many of his films. <br>\nFor all the film’s earthy bawdiness, Pasolini imbued the spirit of and played Giotto, in The Decameron.<br>\nRenoir’s dad and the impressionists clearly influenced the film A Day in the Country, with its swing scene and summer boating (and Satyajit Ray, a great admirer of Jean Renoir, in turn has memorable swing scenes in Charulata and Teen Kanya).</p>\n<p><a href=\"http://www.fineartprintsondemand.com/artists/renoir/swing-400.jpg\" rel=\"nofollow\">The Swing</a> .</p>\n<p><a href=\"http://blogdotriunfo.files.wordpress.com/2009/02/renoir-the-skiff.jpg\" rel=\"nofollow\">The Skiff</a> .</p>\n<p>Bunuel’s <a href=\"http://doisespressos.files.wordpress.com/2009/01/viridiana-ultima-ceia.jpg\" rel=\"nofollow\">Viridiana</a> has a famous frame based on Da Vinci’s Last Supper.</p>\n<p>Carl Dreyer’s admiration for Danish painter <a href=\"http://lapoesiaelospirito.files.wordpress.com/2009/11/hammershoi1.jpg\" rel=\"nofollow\">Vilhelm Hammershoi</a> is reflected in his spare style.</p>\n<p>Kubrick’s Barry Lyndon refers to 18th century paintings, by Gainsborough and Watteau, and uses chiaroscuro with candles to memorable effect, reminiscent of De la Tour, Honthorst..<br>\nDali collaborated with Bunuel early in the latter’s career, and with the dream sequence of Hitchcock’s Spellbound.<br>\nRosi’s Italian classic Salvatore Giuliano refers to Mantegna’s The Dead Christ in its image of the corpse (as Umberto L has pointed out in the forum thread “Our Favourite Paintings: The Great Auteur Gallery”).<br>\nDe Chirico was an influence on surrealism. <br>\nEdward Hopper has been an influence on several directors, e.g Malick’s Days of Heaven, Leth’s New Scenes from America, Hitchcock’s Psycho. e.g <a href=\"http://k-punk.abstractdynamics.org/archives/edward-hopper-house-by-railroad.jpg\" rel=\"nofollow\">here</a> . Days of Heaven also reminds of a famous Wyeth painting, <a href=\"http://2.bp.blogspot.com/-xN0qQZ0mL5Q/TVb95BMSTZI/AAAAAAAAAFA/Ep6A0mlGtfs/s1600/Christinas+World+2.jpg\" rel=\"nofollow\">Christina’s World</a> .</p>\n<p>Edvard Munch’s <a href=\"http://www.kulturkompasset.com/wp-content/uploads/2013/05/Munch-22_-Dance-of-Life-1925.jpg\" rel=\"nofollow\">Dance of Life</a> reminds me of Carnival of Souls. Watkins’ bio of Munch is excellent.</p>\n<p>Fellini Satyricon was influenced by Roman mosaics.<br>\nLachim here has pointed to Friedrich in Herzog films like Aguirre and Fitzcarraldo; certainly the misty cliffs and forests, almost mystical closeness to nature and intrepid hero in Aguirre are Friedrichian (a subject worth further exploration). Herzog’s Cave of Forgotten Dreams is a fascinating documentary on prehistoric cave paintings in France.<br>\nLa Belle Noiseuse is a rather different kettle of fish from other films included, the artist protagonist Frenhofer a loose updated version of Balzac’s novella The Unknown Masterpiece, which greatly interested certain artists, e.g Picasso. Another Rivette film, Hurlevent, was influenced by the controversial artist Balthus.</p>\n<p>The importance of Rubens’ <a href=\"http://www.artinthepicture.com/artists/Peter_Paul_Rubens/descent.jpeg\" rel=\"nofollow\">Descent from the Cross</a> to modern Japanese culture and a popular televised book , is explored in the Belgian documentary Patrasche, a Dog of Flanders.</p>\n<p>Escher fans in particular may find the Hungarian short Mind the Steps of interest. Another strange, disquieting animated short, Priit Parn’s Breakfast on the Grass, was (very loosely) inspired by Manet’s Le Déjeuener sur l’Herbe.</p>\n<p>See also my lists <a href=\"http://mubi.com/lists/9938\" rel=\"nofollow\">The Best Art Films</a>, <a href=\"http://mubi.com/lists/18735\" rel=\"nofollow\">Kenji’s Japanese Art Gallery</a>, <a href=\"http://mubi.com/lists/18802\" rel=\"nofollow\">Kenji’s Welsh Art Gallery</a>, <a href=\"http://mubi.com/lists/kenjis-gallery-of-indian-paintings\" rel=\"nofollow\">Kenji’s Gallery of Indian Paintings</a>, <a href=\"http://mubi.com/lists/paintings-of-spain-and-portugal\" rel=\"nofollow\">Paintings of Spain and Portugal</a>, <a href=\"http://mubi.com/lists/kenjis-journey-into-latin-american-painting-kenji-explora-las-pinturas-latino-americanas\" rel=\"nofollow\">Kenji’s Journey into Latin American Painting</a>, <a href=\"http://mubi.com/lists/kenjis-gallery-of-british-paintings\" rel=\"nofollow\">Kenji’s Gallery of British Paintings</a>, and <a href=\"http://mubi.com/lists/7493\" rel=\"nofollow\">A Visit to the Louvre</a>, with a small gallery of paintings championed in the film by that title</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/300/image-w320.jpg?1578961463",
+      "https://assets.mubicdn.net/images/film/1945/image-w320.jpg?1549468633",
+      "https://assets.mubicdn.net/images/film/32833/image-w320.jpg?1602676263"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 6742,
+    "user_id": 56195,
+    "title": "KENJI's 1000",
+    "list_films_count": 1000,
+    "updated_at": 1625898003,
+    "created_at": 1270151653,
+    "canonical_url": "https://mubi.com/lists/kenjis-canon-the-big-1000",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/6742/image-large.jpg?1622199814",
+      "medium": "https://assets.mubicdn.net/images/list/6742/image-medium.jpg?1622199814",
+      "small": "https://assets.mubicdn.net/images/list/6742/image-small.jpg?1622199814",
+      "square": "https://assets.mubicdn.net/images/list/6742/image-w140.jpg?1622199814"
+    },
+    "fanship_count": 2014,
+    "comment_count": 23,
+    "description": "<p>Just my favourites, so of course there are famous films and directors hard done by. Most films here are not in English, reflecting the reality of film-making worldwide.</p>\n<p>~~</p>\n<p>DIRECTORS WITH MOST FILMS:<br>\nMizoguchi, Satyajit Ray, Hitchcock, Renoir, Bunuel, Bergman, Kurosawa, Ozu.</p>\n<p>NEAR MISSES:<br>\nSallie Gardner at a Gallop,<br>\nWoman Getting into Bed,<br>\nArrival of a Train at Ciotat,<br>\nThe Man with the Rubber Head,<br>\nA Trip to the Moon,<br>\nA Trip Down Market Street Before the Fire,<br>\nCourse a la Saucisse,<br>\nDream of a Rarebit Fiend,<br>\nThe Abyss,<br>\nSuspense,<br>\nThe Immigrant,<br>\nBroken Blossoms,<br>\nThe Cabinet of Dr Caligari,<br>\nThe Goat,<br>\nManhatta,<br>\nThe Phantom Carriage, <br>\nSafety Last,<br>\nThe Smiling Madame Beudet, <br>\nL’Inhumaine.<br>\nThe Navigator,<br>\nSeven Chances,<br>\nBridal Party at Hardanger,<br>\nThe Crowd,<br>\nThe Fall of the House of Usher (Epstein),<br>\nThe Fall of the House of Usher (Webber, Watson),<br>\nThe Little Match Girl,<br>\nBlackmail, <br>\nDiary of a Lost Girl,<br>\nA Propos de Nice,<br>\nOther Men’s Women,<br>\nThe Wonderful Lies of Nina Petrowna,<br>\nKuhle Wampe,<br>\nI Am a Fugitive from a Chain Gang,<br>\nI Was Born But,<br>\nNight at the Crossroads,<br>\nThe Dancing Girl of Izu,<br>\nSnow-White (Fleischer).<br>\nThe Water Magician,<br>\nThe Mascot,<br>\nEl Compadre Mendoza,<br>\nLa Signora di Tutti,<br>\nThe Song of Ceylon,<br>\nLe Crime de Monsieur Lange, <br>\nWife Be Like a Rose,<br>\nOsaka Elegy,<br>\nSisters of the Gion,<br>\nThe Story of a Cheat,<br>\nSylvia Scarlett,<br>\nEasy Living,<br>\nYou Only Live Once,<br>\nPinocchio,<br>\nCourtyard of Ballads,<br>\nShadow of a Doubt,<br>\nA Canterbury Tale,<br>\nJammin’ the Blues,<br>\nMaria Candelaria,<br>\nMinistry of Fear,<br>\nUnder the Bridges,<br>\nCluny Brown,<br>\nFallen Idol,<br>\nForce of Evil,<br>\nMoonrise,<br>\nPortrait of Jennie,<br>\nThieves’ Highway,<br>\nSuch a Pretty Little Beach,<br>\nAventurera,<br>\nPortrait of Madame Yuki,<br>\nThe Day the Earth Stood Still,<br>\nBellissima,<br>\nThe Golden Coach,<br>\nThe White Reindeer,<br>\nNaked Dawn,<br>\nHobson’s Choice,<br>\nVera Cruz, <br>\nLe Amiche,<br>\nOne Froggy Evening, <br>\nCrazed Fruit,<br>\nNightfall,<br>\nKisses,<br>\nThe Tarnished Angels,<br>\nAshes and Diamonds,<br>\nGiants and Toys,<br>\nThe Indian Tomb, <br>\nThe Tiger of Eschnapur,<br>\nShepherds of Orgosolo, <br>\nAnatomy of a Murder,<br>\nThe Ballad of a Soldier,<br>\nThe Housemaid,<br>\nSpartacus,<br>\nWild River, <br>\nThe Young One,<br>\nGirl with a Suitcase,<br>\nLola,<br>\nPigs and Battleships,<br>\nLa Pyramide Humaine, <br>\nVery Nice Very Nice,<br>\nYanco,<br>\nCarnival of Souls,<br>\nChronicle of a Summer,<br>\nConfessions of an Opium Eater,<br>\nThe Easy Life,<br>\nKanchenjungha,<br>\nNine Days of One Year,<br>\nSalvatore Giuliano,<br>\nSundays and Cybele,<br>\nThe Trial (Welles),<br>\nThe Cry (Jires),<br>\nThe Dark Room of Damocles,<br>\nIt’s a  Mad Mad Mad Mad World,<br>\nThe Green Years,<br>\nThe Raven’s End, <br>\nRevolucion,<br>\nShock Corridor,<br>\nDiamonds of the Night,<br>\nGenevieve (Brault),<br>\nGoldfinger,<br>\nLilith,<br>\nManji,<br>\nThe Naked Kiss,<br>\nNoviciat,<br>\nThe Pumpkin Eater,<br>\nBoniface’s Holiday,<br>\nFilm (Schneider),<br>\nThe Ipcress File,<br>\nMy Way Home (Jancso),<br>\nCathy Come Home,<br>\nDeath of a Bureaucrat,<br>\nFaster Pussycat! Kill! Kill!,<br>\nHunger (Carlsen),<br>\nThe Man Who Had His Hair Cut Short,<br>\nThe Shop on the High Street,<br>\nSilence Has No Wings,<br>\nWings (Shepitko),<br>\nThe Affair (Yoshida),<br>\nAnticipation (Godard),<br>\nBrief Encounters,<br>\nThe Commissar,<br>\nFar from Vietnam,<br>\nThe Valley of the Bees,<br>\nThe White Bus,<br>\nThe Eve of Ivan Kupalo (Ilyenko),<br>\nPetulia,,<br>\nThe Valley of the Bees, <br>\nThe Cow,<br>\nThe Jackal of Nahueltoro,<br>\nMidnight Cowboy,<br>\nOur Daily Bread,<br>\nPirosmani,<br>\nDon’t Cry Pretty Girls!,<br>\nDeath in Venice,<br>\nPunishment Park, <br>\nThe Sudden Wealth of the Poor People of Kombach.<br>\nTwo Lane Blacktop.<br>\nWR: Mysteries of the Organism,<br>\nThe Adversary,<br>\nThe Dawns Here Are Quiet,<br>\nSolaris (Tarkovsky),<br>\nThe Day of the Jackal,<br>\nDistant Thunder,<br>\nThe Hour Glass Sanatorium,<br>\nThe Mongols (Kimiavi),<br>\nThrough and Through,<br>\nWe Won’t Grow Old Together. <br>\nThey Do Not Exist,<br>\nIvor the Engine (TV),<br>\nPenda’s Fen,<br>\nThe Innocent (Visconti),<br>\n1900, <br>\nThe American Friend,<br>\nOur Hitler, A Film frorm Germany,<br>\nProvidence,<br>\nUnfinished Piece for Player Piano,<br>\nThe Suspended Vocation,<br>\nAlien,<br>\nThe Bogeyman,<br>\nBlack Jack,<br>\nRaining in the Mountain,<br>\nTestament of Youth (TV),<br>\nTinker Tailor Soldier Spy (TV),<br>\nAlexander the Great (Angelopoulos),<br>\nHopscotch,<br>\nIn Search of Famine,<br>\nPixote,<br>\nThe Aviator’s Wife, <br>\nBody Heat,<br>\nTango, <br>\nVeronika Voss,<br>\nOne Deadly Summer,<br>\nOur Century,<br>\nManuel on the Island of Wonders,<br>\nNausicaa of the Valley of the Wind,<br>\nA Summer at Grandpa’s, <br>\nSunday in the Country,,<br>\nTaipei Story,<br>\nBombay Our City,<br>\nThe Hour of the Star,<br>\nThe Mind of Clay,<br>\nA Room with a View,<br>\nWitness,<br>\nThe Horse Thief.<br>\nThe Terrorizers,<br>\nFull Metal Jacket,<br>\nKing of the Children,<br>\nRouge (Kwan),<br>\nChocolat (Denis),<br>\nFeeling from Mountain and Water,<br>\nBlood (Costa),<br>\nNear Death, <br>\nRecollections of the Yellow House,<br>\nSidewalk Stories,<br>\nNo or the Vainglory of Command,<br>\nHearts of Darkness: A Film-maker’s Apocalypse.,<br>\nLovers on the Bridge,<br>\nNight on Earth,<br>\nMalcolm X,<br>\nThe Passing (Viola),<br>\nBoatman on the River Padma, <br>\nThe Journey (Solanas),<br>\nFarewell My Concubine,<br>\nThe Last Seduction,<br>\nAmateur,<br>\nEd Wood,<br>\nExotica, <br>\nHoop Dreams,<br>\nJeanne la Pucelle: The Battles,<br>\nThe Flower of my Secret,<br>\nHeat,<br>\nLand and Freedom,<br>\nIrma Vep,<br>\nPonette,<br>\nA Summer’s Tale, <br>\nWind (Ivanyi),<br>\nThe Man of the Story,<br>\nTaste of Cherry,<br>\nSecret Défense,<br>\nAudition,<br>\nEyes Wide Shut,<br>\nHumanité,<br>\nOuter Space,<br>\nRatcatcher,<br>\nTime Regained,<br>\nThe Day I Became a Woman,<br>\nLord of the Rings: The Fellowship of the Ring,<br>\nLilya 4-Ever,<br>\nThe Century of the Self, <br>\nEldra,<br>\nGoodbye Dragon Inn,<br>\nThe Life Aquatic with Steve Zissou,<br>\nMachuca,<br>\n2046,<br>\nVideo Game,<br>\nInland Empire,<br>\nThe Lighthouse (Saakyan),<br>\nThe Wind That Shakes the Barley,<br>\nThe Diving Bell and the Butterfly,<br>\nI Don’t Want to Sleep Alone,<br>\nAutumn (Alper),<br>\nBelow Sea Level,<br>\nOur Beloved Month of August, <br>\nSleep Furiously,<br>\nSynecdoche New York,<br>\n35 Shots of Rum,<br>\nWild China,<br>\nPoetry,<br>\nCave of Forgotten Dreams,<br>\nRobinson in Ruins,<br>\nBoro in the Box,<br>\nPina,<br>\nLaurence Anyways,<br>\nThe Recorder Exam,<br>\nEndeavour (TV)<br>\nFrances Ha,<br>\nSpring Breakers,<br>\nThe Seventh Walk,<br>\nVirunga,<br>\nWild Tales,<br>\nThe Handmaiden,<br>\nSami Blood,<br>\nMoonlight,<br>\nAsh is Purest White,<br>\nNooreh, <br>\nFamily Romance LLC, <br>\nThe Souvenir,<br>\nFarewell Amor,<br>\nTalking about Trees, <br>\nBeginning (Kulumbegashvili),<br>\nNomadland,<br>\nShiva Baby.</p>\n<p>__</p>\n<p><strong>SIMILAR MUBI LISTS I RECOMMEND: They Shoot Pictures Don’t They 1000, Jonathan Rosenbaum’s 1000, The Mubi Forum Users’ Top 20 Poll, Blue Kim’s 666 (extended to over 1000), Dionysus67’s 1000, Roy Rezaali’s Forget Film School, David Thomson’s Have You Seen?, and the communal Mubi 1000. I only wish we had 1000 by Apursansar, but his lists by decades will do fine.</strong></p>\n<p>A SHORTER LIST OF <a href=\"https://mubi.com/lists/my-101-favourite-films\" rel=\"nofollow\">FAVOURITES</a> .</p>\n<p>~~</p>\nWe didn’t have a TV till i was 12. My first memory of going to the cinema was Fantasia – my introduction to the devil and dinosaurs. My small town’s cinema closed when i was 7- TV was too strong a competitor-, my sole memory of  films there are of “red Indians” on a hill. The bigger films were at the grand metropolis of the county town of 3,000 people 20 miles away, or an even greater city of a few thousand more in the other direction. How i wept when the child catcher caught them in Chitty Chitty Bang Bang, and the sky outside had changed, with castles hidden in the majestic domes of cumulo-nimbus. At 11, The Great Escape was the greatest adventure, at 12, El Cid. At 13, i joined the school film society. I gazed at the naked female on a motorbike in Vanishing Point- more fun than that boring Wild Strawberries (which I still can’t take to). In my mid teens, the best discoveries were North by Northwest and Fred Astaire. At uni, on a French course, my special subject was French Cinema of the 30s- Renoir and Pagnol..- but i really got obsessively hooked on world cinema once i’d bought a video player in the late 80s (those Wenders road movies!) and John Kobal’s book The Top 100 Movies (see my list on that); Seven Samurai and 2001 inspired awe, while Tarkovsky and Mizoguchi were new names to me. Soon i saw Andrei Rublev and the rain and light had changed. Then a few years on (much less availability in those days) it was the turn of Sansho the Bailiff.\n<p><sub>~</sub></p>\n<p>I’ve been asked to do a list of all my lists, but that would take time and anyway would get jumbled in with the others. So here are the ones i like and the most popular.</p>\n<p><a href=\"http://mubi.com/lists/kenjis-japanese-canon\" rel=\"nofollow\">Essential Japanese Films</a> ,<br>\n<a href=\"http://mubi.com/lists/essential-films-by-women\" rel=\"nofollow\">Essential Films by Women</a> ,<br>\n<a href=\"http://mubi.com/lists/19805\" rel=\"nofollow\">The Labyrinth</a> ,<br>\n<a href=\"http://mubi.com/lists/973\" rel=\"nofollow\">The Mubi/Auteurs World Cup Films</a> ,<br>\n<a href=\"http://mubi.com/lists/the-welsh-connection\" rel=\"nofollow\">The Welsh Connection</a> ,<br>\n<a href=\"http://mubi.com/lists/4775\" rel=\"nofollow\">Mizoguchi Revered</a> ,<br>\n<a href=\"https://mubi.com/lists/let-there-be-light-the-birth-of-films-to-1899\" rel=\"nofollow\">Let There be Light: The Birth of Films</a> ,<br>\n<a href=\"https://mubi.com/lists/notable-films-by-black-directors\" rel=\"nofollow\">Notable Films by Black Directors</a> ,<br>\n<a href=\"https://mubi.com/lists/essayists-diarists-musersfunambulists-of-free-thought\" rel=\"nofollow\">Essayists, Diarists, Musers..Funambulists of Free Thought</a> , <br>\n<a href=\"http://mubi.com/lists/7258\" rel=\"nofollow\">A Rosefinch Sang: the Czechoslovakian New Wave</a> ,<br>\n<a href=\"https://mubi.com/lists/kenji-s-own-haiku-treasury\" rel=\"nofollow\">My Haiku</a> ,<br>\n<a href=\"http://mubi.com/lists/19th-century-britain\" rel=\"nofollow\">19th Century Britain</a> ,<br>\n<a href=\"http://mubi.com/lists/essential-french-films\" rel=\"nofollow\">Essential French Films</a> ,<br>\n<a href=\"https://mubi.com/lists/101-directors-essential-films\" rel=\"nofollow\">100 Directors’ Essential Films</a> ,<br>\n<a href=\"http://mubi.com/lists/Essential-African-Films\" rel=\"nofollow\">Essential African Films</a> ,<br>\n<a href=\"https://mubi.com/lists/portugal-land-of-my-dreams\" rel=\"nofollow\">Portugal, Land of My Dreams</a> ,<br>\n<a href=\"http://mubi.com/lists/they-do-not-exist-palestine\" rel=\"nofollow\">They Do Not Exist: Palestine</a> ,<br>\n<a href=\"https://mubi.com/lists/lesotho\" rel=\"nofollow\">We Love Lesotho</a> ,<br>\n<a href=\"https://mubi.com/lists/favourite-indian-films\" rel=\"nofollow\">India</a> ,<br>\n<a href=\"https://mubi.com/lists/essential-iranian-films\" rel=\"nofollow\">Essential Iranian Films</a> ,<br>\n<a href=\"https://mubi.com/lists/turkey\" rel=\"nofollow\">Essential Turkish Films</a> ,<br>\n<a href=\"https://mubi.com/lists/101-favourite-documentaries\" rel=\"nofollow\">Essential Documentaries</a> ,<br>\n<a href=\"http://mubi.com/lists/favourite-short-films\" rel=\"nofollow\">Essential Short Films &amp; Featurettes</a> ,<br>\n<a href=\"https://mubi.com/lists/favourite-animations\" rel=\"nofollow\">Essential Animation</a> ,<br>\n<a href=\"http://mubi.com/lists/hidden-treasures\" rel=\"nofollow\">Hidden Treasures</a> ,<br>\n<a href=\"https://mubi.com/lists/le-cinema-cest-jean-renoir\" rel=\"nofollow\">Le Cinema, c’est Jean Renoir</a> ,<br>\n<a href=\"http://mubi.com/lists/satyajit-ray--3\" rel=\"nofollow\">Satyajit Ray</a> ,<br>\n<a href=\"https://mubi.com/lists/kubrick--14\" rel=\"nofollow\">Kubrick, With A-Z Guide</a> ,<br>\n<a href=\"https://mubi.com/lists/essential-hitchcock\" rel=\"nofollow\">Essential Hitchcock, With A-Z Guide</a> ,<br>\n<a href=\"https://mubi.com/lists/eric-rohmer--3\" rel=\"nofollow\">Eric Rohmer &amp; His Legacy</a> ,<br>\n<a href=\"https://mubi.com/lists/essential-godard--2\" rel=\"nofollow\">Essential Godard: More Than a List</a> ,<br>\n<a href=\"https://mubi.com/lists/leftist-films\" rel=\"nofollow\">Leftist Films</a> ,<br>\n<a href=\"https://mubi.com/lists/great-cinematographers\" rel=\"nofollow\">Great Cinematographers</a> ,<br>\n<a href=\"https://mubi.com/lists/films-admired-by-tarkovsky\" rel=\"nofollow\">Films Admired by Tarkovsky</a> ,<br>\n<a href=\"https://mubi.com/lists/susan-sontags-favourite-films\" rel=\"nofollow\">Susan Sontag’s Favourite Films</a> ,<br>\n<a href=\"https://mubi.com/lists/mental-illness\" rel=\"nofollow\">Mental Health</a> ,<br>\n<a href=\"https://mubi.com/lists/films-about-film--4\" rel=\"nofollow\">Films about Film</a> .<br>\n<a href=\"https://mubi.com/lists/painters-and-films\" rel=\"nofollow\">Painters and Films</a> ,<br>\n<a href=\"https://mubi.com/lists/kenjis-poetry-anthology-part-1\" rel=\"nofollow\">Kenji’s Poetry Anthology 1</a> ,<br>\n<a href=\"https://mubi.com/lists/kenjis-poetry-anthology-part-2\" rel=\"nofollow\">Kenji’s Poetry Anthology 2</a></p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/18186/image-w320.jpg?1607249060",
+      "https://assets.mubicdn.net/images/film/2191/image-w320.jpg?1481542114",
+      "https://assets.mubicdn.net/images/film/1418/image-w320.jpg?1481541252"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 177680,
+    "user_id": 56195,
+    "title": "COMIC Satire",
+    "list_films_count": 43,
+    "updated_at": 1625886077,
+    "created_at": 1555308987,
+    "canonical_url": "https://mubi.com/lists/satirical-comedy",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/film/315/image-w1280.jpg?1543575642",
+      "medium": "https://assets.mubicdn.net/images/film/315/image-w384.jpg?1543575642",
+      "small": "https://assets.mubicdn.net/images/film/315/image-w128.jpg?1543575642",
+      "square": "https://assets.mubicdn.net/images/film/315/image-w140.jpg?1543575642"
+    },
+    "fanship_count": 5,
+    "comment_count": 0,
+    "description": "<p>in progress, suggestions welcome</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/315/image-w320.jpg?1543575642",
+      "https://assets.mubicdn.net/images/film/606/image-w320.jpg?1546146039",
+      "https://assets.mubicdn.net/images/film/1535/image-w320.jpg?1572001746"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 176872,
+    "user_id": 56195,
+    "title": "Mother and Son",
+    "list_films_count": 23,
+    "updated_at": 1625886077,
+    "created_at": 1553547308,
+    "canonical_url": "https://mubi.com/lists/mother-and-son-b8f001a6-3e1b-4615-bf93-46308e7b0c2f",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/film/823/image-w1280.jpg?1546946131",
+      "medium": "https://assets.mubicdn.net/images/film/823/image-w384.jpg?1546946131",
+      "small": "https://assets.mubicdn.net/images/film/823/image-w128.jpg?1546946131",
+      "square": "https://assets.mubicdn.net/images/film/823/image-w140.jpg?1546946131"
+    },
+    "fanship_count": 5,
+    "comment_count": 0,
+    "description": "<p>See also my list Father and Daughter. Recommended films, including adoption and animals.</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/823/image-w320.jpg?1546946131",
+      "https://assets.mubicdn.net/images/film/1231/image-w320.jpg?1546732822",
+      "https://assets.mubicdn.net/images/film/775/image-w320.jpg?1574070305"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 156698,
+    "user_id": 56195,
+    "title": "MUBI'S HIGHEST RATED FILMS & TV",
+    "list_films_count": 210,
+    "updated_at": 1625886070,
+    "created_at": 1510733983,
+    "canonical_url": "https://mubi.com/lists/films-with-high-mubi-average-ratings",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/156698/image-large.jpg?1620023572",
+      "medium": "https://assets.mubicdn.net/images/list/156698/image-medium.jpg?1620023572",
+      "small": "https://assets.mubicdn.net/images/list/156698/image-small.jpg?1620023572",
+      "square": "https://assets.mubicdn.net/images/list/156698/image-w140.jpg?1620023572"
+    },
+    "fanship_count": 300,
+    "comment_count": 25,
+    "description": "<p>Updated June 2021. Please comment with any missing film rated 8.7 or more, with minimum 100 votes. Films with equal scores are arranged by order of number of votes. Tarkovsky’s 7 feature films all have ratings of 8.5 or more. A few more Bergman, Kubrick and Kurosawa films narrowly miss the cut too.</p>\n<p>It looks as if Mubi has attracted a good number of fans of Sakamoto Ryuichi, The Blue Blues Band, Max Richter and Nils Frahm!</p>\n<p>Highly rated films with insufficient ratings:<br>\nBelfast Maine,<br>\nThe Blue Planet,<br>\nBlue Planet II,<br>\nThe Fellowship of the Ring- Extended Version,<br>\nFive Year Diary (Robertson),<br>\nThe Hour of Liberation Has Arrived,<br>\nHow Yukong Moved the Mountains,<br>\nMughal E Azam (1960),<br>\nRoundabout (Berkovic),<br>\nSiddeshwari,<br>\nTomka and his Friends,<br>\nValparaiso Mi Amor,</p>\n<p>Directors’ films included:<br>\nBergman 6<br>\nKurosawa 6<br>\nVarda 6<br>\nMizoguchi 5<br>\nTarkovsky 5<br>\nChaplin 4<br>\nKubrick 4<br>\nRay 4<br>\nCoppola 3<br>\nDreyer 3<br>\nHitchcock 3<br>\nKeaton 3<br>\nOzu 3</p>",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/169097/image-w320.jpg?1618781706",
+      "https://assets.mubicdn.net/images/film/22742/image-w320.jpg?1548073042",
+      "https://assets.mubicdn.net/images/film/23369/image-w320.jpg?1481154384"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  },
+  {
+    "id": 159373,
+    "user_id": 56195,
+    "title": "Female-Centred",
+    "list_films_count": 384,
+    "updated_at": 1625886070,
+    "created_at": 1516014621,
+    "canonical_url": "https://mubi.com/lists/best-female-centred-films",
+    "image_urls": {
+      "large": "https://assets.mubicdn.net/images/list/159373/image-large.jpg?1554742617",
+      "medium": "https://assets.mubicdn.net/images/list/159373/image-medium.jpg?1554742617",
+      "small": "https://assets.mubicdn.net/images/list/159373/image-small.jpg?1554742617",
+      "square": "https://assets.mubicdn.net/images/list/159373/image-w140.jpg?1554742617"
+    },
+    "fanship_count": 31,
+    "comment_count": 2,
+    "description": "",
+    "title_locale": "en",
+    "thumbnail_urls": [
+      "https://assets.mubicdn.net/images/film/228/image-w320.jpg?1610998586",
+      "https://assets.mubicdn.net/images/film/1701/image-w320.jpg?1481541587",
+      "https://assets.mubicdn.net/images/film/5148/image-w320.jpg?1546970420"
+    ],
+    "user": {
+      "id": 56195,
+      "name": "Kenji",
+      "canonical_url": "https://mubi.com/users/56195",
+      "avatar_url": "https://images.mubicdn.net/images/avatars/4345/cache-4345-1523884053/images-large.jpg?size=150x150",
+      "bio": "On my list Kenji's 1000 you can find my 1000 favourite films and my own favourite lists. ",
+      "subscriber": true,
+      "cover_image_url": "https://assets.mubicdn.net/images/cover_images/86700/images-small.jpg?1552259561",
+      "has_payment_method": true,
+      "eligible_for_trial": false,
+      "trialist": false
+    }
+  }
+]


### PR DESCRIPTION
This branch adds support for getting a user's lists.

Example command implemented for the user's lists at https://mubi.com/users/56195/lists:

```
$ mubi lists --userid 56195 --page=1 --per-page=5
ESSENTIAL FILMS BY WOMEN (464 films) - https://mubi.com/lists/essential-films-by-women
Created on 2009-11-11 12:25:51 +0100 CET
Updated on 2021-07-10 18:31:32 +0200 CEST
-----
100 DIRECTORS' ESSENTIAL FILMS (673 films) - https://mubi.com/lists/101-directors-essential-films
Created on 2010-03-05 13:24:12 +0100 CET
Updated on 2021-07-10 18:02:37 +0200 CEST
-----
MY FAVOURITE FILMS BY WOMEN (41 films) - https://mubi.com/lists/my-favourite-films-by-women
Created on 2011-06-30 12:33:19 +0200 CEST
Updated on 2021-07-10 16:52:09 +0200 CEST
-----
ÉRIC ROHMER's LEGACY (77 films) - https://mubi.com/lists/eric-rohmer--3
Created on 2010-04-07 15:16:20 +0200 CEST
Updated on 2021-07-10 15:02:30 +0200 CEST
-----
ESSENTIAL IRANIAN FILMS (112 films) - https://mubi.com/lists/essential-iranian-films
Created on 2009-11-11 20:44:34 +0100 CET
Updated on 2021-07-10 13:20:34 +0200 CEST
-----
```
